### PR TITLE
Set the INTERFACE_INCLUDE_DIRECTORIES on the dccl library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # this project is intended to be built out of source by using 
 # > ./build.sh
 
-cmake_minimum_required(VERSION 2.6.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
 project(dccl)
 
 ## allows us to write custom modules or modifying existing ones

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,10 @@ endif()
 
 set_target_properties(dccl PROPERTIES VERSION "${DCCL_VERSION}" SOVERSION "${DCCL_SOVERSION}")
 
+set_property(TARGET dccl APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+  $<BUILD_INTERFACE:${dccl_INC_DIR}>
+  $<INSTALL_INTERFACE:include>  # <prefix>/include
+)
 
 install(TARGETS dccl EXPORT dccl-config
    LIBRARY DESTINATION lib
@@ -62,7 +66,6 @@ if(build_arithmetic)
 endif()
 
 export(TARGETS ${DCCL_EXPORT_TARGETS} FILE ${CMAKE_BINARY_DIR}/dccl-config.cmake)
-file(APPEND ${CMAKE_BINARY_DIR}/dccl-config.cmake "set(DCCL_INCLUDE_DIR \"${dccl_INC_DIR}\")")
 
 if(enable_testing)
   add_subdirectory(test)


### PR DESCRIPTION
This lets downstream users import the library regardless of install location and get the install directories (e.g. for passing to protoc for compiling the DCCL .proto files). For example:

``` cmake
find_package(DCCL REQUIRED)     
get_target_property(DCCL_INCLUDE_DIR dccl INTERFACE_INCLUDE_DIRECTORIES)
protobuf_include_dirs("${DCCL_INCLUDE_DIR}")
```

@berkowski: Could you look at this change (and the corresponding merge request GobySoft/goby#2 and let me know if this fixes your problem building Goby against DCCL installed in /opt)?
