### PR TITLE
3.0 update copyright

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,27 @@
+== Core Authors ==
+
+DCCL is primarily authored by:
+
+Toby Schneider: https://github.com/tsaubergine
+GobySoft dccl-dev team:  https://github.com/orgs/GobySoft/teams/dccl-dev
+
+== MIT Authors ==
+
+DCCL started as part of the Goby Underwater Autonomy Project, a project with the Massachusetts Institute of Technology. Please see the AUTHORS file within that project for more details: https://github.com/GobySoft/goby/blob/2.1/AUTHORS
+
+== Community contributions to DCCL ==
+
+We greatly appreciate contributions of code, bug fixes, and documentation from the community.
+
+Before contributing to DCCL, in order for us to use your contribution and distribute it under the existing open source licenses, we request that you read the appropriate Contributor License Agreement (CLA) located at:
+
+Individuals: 
+  http://gobysoft.org/dl/gobysoft_contributor_license_agreement-individual.pdf
+Entities:
+  http://gobysoft.org/dl/gobysoft_contributor_license_agreement-entity.pdf
+
+** Please note **: This CLA does not take away your copyright, it merely gives us a license to use your open source contribution.
+
+To accept this CLA, please add your name, email, and date to the list below, and commit the change using your name and email. Committing your name electronically with your SSH key will be considered a substitute for your physical signature:
+
+Toby Schneider <toby@gobysoft.org> 2016-05-13

--- a/dccl.h
+++ b/dccl.h
@@ -1,27 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Goby Underwater Autonomy Project Libraries
-// ("The Goby Libraries").
-//
-// The Goby Libraries are free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The Goby Libraries are distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // courtesy header for the Dynamic Compact Control Language Library
 // (libdccl)
 

--- a/share/examples/quickstart_navreport/quick.cpp
+++ b/share/examples/quickstart_navreport/quick.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "dccl.h"
 #include "navreport.pb.h"
 #include <iostream>

--- a/share/header_lib.txt
+++ b/share/header_lib.txt
@@ -1,6 +1,6 @@
 // Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
 //                     Community contributors (see AUTHORS file)
 //
 //

--- a/share/header_lib.txt
+++ b/share/header_lib.txt
@@ -1,17 +1,18 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
 //                     GobySoft, LLC (2013-)
 //                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
+//                     Community contributors (see AUTHORS file)
+//
 //
 // This file is part of the Dynamic Compact Control Language Library
 // ("DCCL").
 //
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 2.1 of the License, or
 // (at your option) any later version.
 //
-// DCCL is distributed in the hope that they will be useful,
+// DCCL is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Lesser General Public License for more details.

--- a/share/header_lib_gs.txt
+++ b/share/header_lib_gs.txt
@@ -1,6 +1,6 @@
-// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
-//                     GobySoft, LLC (for 2013-)
-//                     Massachusetts Institute of Technology (for 2007-2014)
+// Copyright 2015-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     Stephanie Petillo (http://gobysoft.org/index.wt/people/stephanie)
+//                     GobySoft, LLC
 //                     Community contributors (see AUTHORS file)
 //
 //
@@ -19,14 +19,3 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-// courtesy header for the Dynamic Compact Control Language Library
-// (libdccl)
-
-#ifndef DCCL3COURTESY20091211H
-#define DCCL3COURTESY20091211H
-
-#include "dccl/codec.h"
-
-/// \defgroup dccl_api API class for using the DCCL Codec
-/// \defgroup dccl_field_api API classes for defining new custom field encoders/decoders
-#endif

--- a/share/header_lib_gs.txt
+++ b/share/header_lib_gs.txt
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+// Copyright 2014-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
 //                     Stephanie Petillo (http://gobysoft.org/index.wt/people/stephanie)
 //                     GobySoft, LLC
 //                     Community contributors (see AUTHORS file)

--- a/src/apps/analyze_dccl/analyze_dccl.cpp
+++ b/src/apps/analyze_dccl/analyze_dccl.cpp
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <google/protobuf/descriptor.h>
 
 #include "dccl/codec.h"

--- a/src/apps/analyze_dccl/analyze_dccl.cpp
+++ b/src/apps/analyze_dccl/analyze_dccl.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <google/protobuf/descriptor.h>
 
 #include "dccl/codec.h"

--- a/src/apps/dccl/dccl_tool.cpp
+++ b/src/apps/dccl/dccl_tool.cpp
@@ -1,23 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 //
 // For the 'dccl' tool: loading non-GPL shared libraries for the purpose of
 // using this tool does *not* violate the GPL license terms of DCCL.

--- a/src/apps/dccl/dccl_tool.cpp
+++ b/src/apps/dccl/dccl_tool.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 //
 // For the 'dccl' tool: loading non-GPL shared libraries for the purpose of
 // using this tool does *not* violate the GPL license terms of DCCL.

--- a/src/apps/pb_plugin/gen_units_class_plugin.h
+++ b/src/apps/pb_plugin/gen_units_class_plugin.h
@@ -1,23 +1,3 @@
-// Copyright 2014-2015 Toby Schneider (https://launchpad.net/~tes)
-//                     Stephanie Petillo (https://launchpad.net/~spetillo)
-//                     GobySoft, LLC
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #ifndef GenUnitsClassPlugin20150310H
 #define GenUnitsClassPlugin20150310H
 

--- a/src/apps/pb_plugin/gen_units_class_plugin.h
+++ b/src/apps/pb_plugin/gen_units_class_plugin.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef GenUnitsClassPlugin20150310H
 #define GenUnitsClassPlugin20150310H
 

--- a/src/apps/pb_plugin/gen_units_class_plugin.h
+++ b/src/apps/pb_plugin/gen_units_class_plugin.h
@@ -1,6 +1,6 @@
-// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
-//                     GobySoft, LLC (for 2013-)
-//                     Massachusetts Institute of Technology (for 2007-2014)
+// Copyright 2015-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     Stephanie Petillo (http://gobysoft.org/index.wt/people/stephanie)
+//                     GobySoft, LLC
 //                     Community contributors (see AUTHORS file)
 //
 //

--- a/src/apps/pb_plugin/gen_units_class_plugin.h
+++ b/src/apps/pb_plugin/gen_units_class_plugin.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+// Copyright 2014-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
 //                     Stephanie Petillo (http://gobysoft.org/index.wt/people/stephanie)
 //                     GobySoft, LLC
 //                     Community contributors (see AUTHORS file)

--- a/src/apps/pb_plugin/pb_plugin.cpp
+++ b/src/apps/pb_plugin/pb_plugin.cpp
@@ -1,23 +1,3 @@
-// Copyright 2014-2015 Toby Schneider (https://launchpad.net/~tes)
-//                     Stephanie Petillo (https://launchpad.net/~spetillo)
-//                     GobySoft, LLC
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <google/protobuf/compiler/plugin.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/compiler/code_generator.h>

--- a/src/apps/pb_plugin/pb_plugin.cpp
+++ b/src/apps/pb_plugin/pb_plugin.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <google/protobuf/compiler/plugin.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/compiler/code_generator.h>

--- a/src/apps/pb_plugin/pb_plugin.cpp
+++ b/src/apps/pb_plugin/pb_plugin.cpp
@@ -1,6 +1,6 @@
-// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
-//                     GobySoft, LLC (for 2013-)
-//                     Massachusetts Institute of Technology (for 2007-2014)
+// Copyright 2015-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     Stephanie Petillo (http://gobysoft.org/index.wt/people/stephanie)
+//                     GobySoft, LLC
 //                     Community contributors (see AUTHORS file)
 //
 //

--- a/src/apps/pb_plugin/pb_plugin.cpp
+++ b/src/apps/pb_plugin/pb_plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+// Copyright 2014-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
 //                     Stephanie Petillo (http://gobysoft.org/index.wt/people/stephanie)
 //                     GobySoft, LLC
 //                     Community contributors (see AUTHORS file)

--- a/src/arithmetic/field_codec_arithmetic.cpp
+++ b/src/arithmetic/field_codec_arithmetic.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 #include "field_codec_arithmetic.h"
 #include "dccl/field_codec_manager.h"
 

--- a/src/arithmetic/field_codec_arithmetic.cpp
+++ b/src/arithmetic/field_codec_arithmetic.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "field_codec_arithmetic.h"
 #include "dccl/field_codec_manager.h"
 

--- a/src/arithmetic/field_codec_arithmetic.h
+++ b/src/arithmetic/field_codec_arithmetic.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 // This code is adapted from the reference code provided by Witten et al. "Arithmetic Coding for Data Compression," Communications of the ACM, June 1987, Vol 30, Number 6
 
 

--- a/src/arithmetic/field_codec_arithmetic.h
+++ b/src/arithmetic/field_codec_arithmetic.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // This code is adapted from the reference code provided by Witten et al. "Arithmetic Coding for Data Compression," Communications of the ACM, June 1987, Vol 30, Number 6
 
 

--- a/src/b64/cdecode.h
+++ b/src/b64/cdecode.h
@@ -1,24 +1,3 @@
-// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
-//                     GobySoft, LLC (for 2013-)
-//                     Massachusetts Institute of Technology (for 2007-2014)
-//                     Community contributors (see AUTHORS file)
-//
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 /*
 cdecode.h - c header for a base64 decoding algorithm
 

--- a/src/b64/cdecode.h
+++ b/src/b64/cdecode.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 /*
 cdecode.h - c header for a base64 decoding algorithm
 

--- a/src/b64/cencode.h
+++ b/src/b64/cencode.h
@@ -1,24 +1,3 @@
-// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
-//                     GobySoft, LLC (for 2013-)
-//                     Massachusetts Institute of Technology (for 2007-2014)
-//                     Community contributors (see AUTHORS file)
-//
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 /*
 cencode.h - c header for a base64 encoding algorithm
 

--- a/src/b64/cencode.h
+++ b/src/b64/cencode.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 /*
 cencode.h - c header for a base64 encoding algorithm
 

--- a/src/b64/decode.h
+++ b/src/b64/decode.h
@@ -1,24 +1,3 @@
-// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
-//                     GobySoft, LLC (for 2013-)
-//                     Massachusetts Institute of Technology (for 2007-2014)
-//                     Community contributors (see AUTHORS file)
-//
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // :mode=c++:
 /*
 decode.h - c++ wrapper for a base64 decoding algorithm

--- a/src/b64/decode.h
+++ b/src/b64/decode.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // :mode=c++:
 /*
 decode.h - c++ wrapper for a base64 decoding algorithm

--- a/src/b64/encode.h
+++ b/src/b64/encode.h
@@ -1,24 +1,3 @@
-// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
-//                     GobySoft, LLC (for 2013-)
-//                     Massachusetts Institute of Technology (for 2007-2014)
-//                     Community contributors (see AUTHORS file)
-//
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // :mode=c++:
 /*
 encode.h - c++ wrapper for a base64 encoding algorithm

--- a/src/b64/encode.h
+++ b/src/b64/encode.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // :mode=c++:
 /*
 encode.h - c++ wrapper for a base64 encoding algorithm

--- a/src/binary.h
+++ b/src/binary.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLBINARY20100713H
 #define DCCLBINARY20100713H
 

--- a/src/binary.h
+++ b/src/binary.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLBINARY20100713H
 #define DCCLBINARY20100713H
 

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -1,25 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 #include "bitset.h"
 #include "dccl/codec.h"
 

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "bitset.h"
 #include "dccl/codec.h"
 

--- a/src/bitset.h
+++ b/src/bitset.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLBITSET20120424H
 #define DCCLBITSET20120424H
 

--- a/src/bitset.h
+++ b/src/bitset.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLBITSET20120424H
 #define DCCLBITSET20120424H
 

--- a/src/ccl/WhoiUtil.cpp
+++ b/src/ccl/WhoiUtil.cpp
@@ -1,25 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <time.h>   // P.Brodsky
 #include <stdio.h>
 #include <iostream>

--- a/src/ccl/WhoiUtil.cpp
+++ b/src/ccl/WhoiUtil.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <time.h>   // P.Brodsky
 #include <stdio.h>
 #include <iostream>

--- a/src/ccl/WhoiUtil.h
+++ b/src/ccl/WhoiUtil.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 /* Latitude/Longitude 
  * Each are encoded into 3 bytes, giving a resolution of
  * about 2 meters. The compressed form is stored in a LATLON_COMPRESSED struct, 

--- a/src/ccl/WhoiUtil.h
+++ b/src/ccl/WhoiUtil.h
@@ -1,25 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 /* Latitude/Longitude 
  * Each are encoded into 3 bytes, giving a resolution of
  * about 2 meters. The compressed form is stored in a LATLON_COMPRESSED struct, 

--- a/src/ccl/ccl_compatibility.cpp
+++ b/src/ccl/ccl_compatibility.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 #include <ctime>
 
 #include <boost/date_time.hpp>

--- a/src/ccl/ccl_compatibility.cpp
+++ b/src/ccl/ccl_compatibility.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <ctime>
 
 #include <boost/date_time.hpp>

--- a/src/ccl/ccl_compatibility.h
+++ b/src/ccl/ccl_compatibility.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLCCLCOMPATIBILITY20120426H
 #define DCCLCCLCOMPATIBILITY20120426H
 

--- a/src/ccl/ccl_compatibility.h
+++ b/src/ccl/ccl_compatibility.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 #ifndef DCCLCCLCOMPATIBILITY20120426H
 #define DCCLCCLCOMPATIBILITY20120426H
 

--- a/src/cli_option.h
+++ b/src/cli_option.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef CLIOPTION20140107H
 #define CLIOPTION20140107H
 

--- a/src/cli_option.h
+++ b/src/cli_option.h
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #ifndef CLIOPTION20140107H
 #define CLIOPTION20140107H
 

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <algorithm>
 
 #include <dlfcn.h> // for shared library loading

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <algorithm>
 
 #include <dlfcn.h> // for shared library loading

--- a/src/codec.h
+++ b/src/codec.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCL20091211H
 #define DCCL20091211H
 

--- a/src/codec.h
+++ b/src/codec.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCL20091211H
 #define DCCL20091211H
 

--- a/src/codecs2/field_codec_default.cpp
+++ b/src/codecs2/field_codec_default.cpp
@@ -1,27 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
-
 #include <sstream>
 #include <algorithm>
 

--- a/src/codecs2/field_codec_default.cpp
+++ b/src/codecs2/field_codec_default.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <sstream>
 #include <algorithm>
 

--- a/src/codecs2/field_codec_default.h
+++ b/src/codecs2/field_codec_default.h
@@ -1,27 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // implements FieldCodecBase for all the basic DCCL types
 
 #ifndef DCCLFIELDCODECDEFAULT20110322H

--- a/src/codecs2/field_codec_default.h
+++ b/src/codecs2/field_codec_default.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // implements FieldCodecBase for all the basic DCCL types
 
 #ifndef DCCLFIELDCODECDEFAULT20110322H

--- a/src/codecs2/field_codec_default_message.cpp
+++ b/src/codecs2/field_codec_default_message.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #include "dccl/codec.h"
 #include "field_codec_default_message.h"
 

--- a/src/codecs2/field_codec_default_message.cpp
+++ b/src/codecs2/field_codec_default_message.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "dccl/codec.h"
 #include "field_codec_default_message.h"
 

--- a/src/codecs2/field_codec_default_message.h
+++ b/src/codecs2/field_codec_default_message.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLFIELDCODECDEFAULTMESSAGE20110510H
 #define DCCLFIELDCODECDEFAULTMESSAGE20110510H
 

--- a/src/codecs2/field_codec_default_message.h
+++ b/src/codecs2/field_codec_default_message.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLFIELDCODECDEFAULTMESSAGE20110510H
 #define DCCLFIELDCODECDEFAULTMESSAGE20110510H
 

--- a/src/codecs3/field_codec_default.cpp
+++ b/src/codecs3/field_codec_default.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "dccl/codecs3/field_codec_default.h"
 
 using namespace dccl::logger;

--- a/src/codecs3/field_codec_default.cpp
+++ b/src/codecs3/field_codec_default.cpp
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include "dccl/codecs3/field_codec_default.h"
 
 using namespace dccl::logger;

--- a/src/codecs3/field_codec_default.h
+++ b/src/codecs3/field_codec_default.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // implements FieldCodecBase for all the basic DCCL types for version 3
 
 #ifndef DCCLV3FIELDCODECDEFAULT20140403H

--- a/src/codecs3/field_codec_default.h
+++ b/src/codecs3/field_codec_default.h
@@ -1,27 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // implements FieldCodecBase for all the basic DCCL types for version 3
 
 #ifndef DCCLV3FIELDCODECDEFAULT20140403H

--- a/src/codecs3/field_codec_default_message.cpp
+++ b/src/codecs3/field_codec_default_message.cpp
@@ -1,27 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #include "dccl/codec.h"
 #include "dccl/codecs3/field_codec_default_message.h"
 

--- a/src/codecs3/field_codec_default_message.cpp
+++ b/src/codecs3/field_codec_default_message.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "dccl/codec.h"
 #include "dccl/codecs3/field_codec_default_message.h"
 

--- a/src/codecs3/field_codec_default_message.h
+++ b/src/codecs3/field_codec_default_message.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLFIELDCODECDEFAULTMESSAGEV320140421H
 #define DCCLFIELDCODECDEFAULTMESSAGEV320140421H
 

--- a/src/codecs3/field_codec_default_message.h
+++ b/src/codecs3/field_codec_default_message.h
@@ -1,27 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLFIELDCODECDEFAULTMESSAGEV320140421H
 #define DCCLFIELDCODECDEFAULTMESSAGEV320140421H
 

--- a/src/common.h
+++ b/src/common.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLConstants20091211H
 #define DCCLConstants20091211H
 

--- a/src/common.h
+++ b/src/common.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLConstants20091211H
 #define DCCLConstants20091211H
 

--- a/src/dynamic_protobuf_manager.cpp
+++ b/src/dynamic_protobuf_manager.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <sstream>
 
 #include "dynamic_protobuf_manager.h"

--- a/src/dynamic_protobuf_manager.cpp
+++ b/src/dynamic_protobuf_manager.cpp
@@ -1,25 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 #include <sstream>
 
 #include "dynamic_protobuf_manager.h"

--- a/src/dynamic_protobuf_manager.h
+++ b/src/dynamic_protobuf_manager.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLDYNAMICPROTOBUFMANAGER20110419H
 #define DCCLDYNAMICPROTOBUFMANAGER20110419H
 

--- a/src/dynamic_protobuf_manager.h
+++ b/src/dynamic_protobuf_manager.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLDYNAMICPROTOBUFMANAGER20110419H
 #define DCCLDYNAMICPROTOBUFMANAGER20110419H
 

--- a/src/exception.h
+++ b/src/exception.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef Exception20100812H
 #define Exception20100812H
 

--- a/src/exception.h
+++ b/src/exception.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef Exception20100812H
 #define Exception20100812H
 

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <boost/algorithm/string.hpp> // for replace_all
 
 #include "field_codec.h"

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <boost/algorithm/string.hpp> // for replace_all
 
 #include "field_codec.h"

--- a/src/field_codec.h
+++ b/src/field_codec.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLFIELDCODEC20110322H
 #define DCCLFIELDCODEC20110322H
 

--- a/src/field_codec.h
+++ b/src/field_codec.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLFIELDCODEC20110322H
 #define DCCLFIELDCODEC20110322H
 

--- a/src/field_codec_fixed.h
+++ b/src/field_codec_fixed.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLFIELDCODEC20110510H
 #define DCCLFIELDCODEC20110510H
 

--- a/src/field_codec_fixed.h
+++ b/src/field_codec_fixed.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLFIELDCODEC20110510H
 #define DCCLFIELDCODEC20110510H
 

--- a/src/field_codec_id.cpp
+++ b/src/field_codec_id.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "field_codec_id.h"
 
 //

--- a/src/field_codec_id.cpp
+++ b/src/field_codec_id.cpp
@@ -1,25 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include "field_codec_id.h"
 
 //

--- a/src/field_codec_id.h
+++ b/src/field_codec_id.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "field_codec_fixed.h"
 
 namespace dccl

--- a/src/field_codec_id.h
+++ b/src/field_codec_id.h
@@ -1,25 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include "field_codec_fixed.h"
 
 namespace dccl

--- a/src/field_codec_manager.cpp
+++ b/src/field_codec_manager.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "field_codec_manager.h"
 
 std::map<google::protobuf::FieldDescriptor::Type, dccl::FieldCodecManager::InsideMap> dccl::FieldCodecManager::codecs_;

--- a/src/field_codec_manager.cpp
+++ b/src/field_codec_manager.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #include "field_codec_manager.h"
 
 std::map<google::protobuf::FieldDescriptor::Type, dccl::FieldCodecManager::InsideMap> dccl::FieldCodecManager::codecs_;

--- a/src/field_codec_manager.h
+++ b/src/field_codec_manager.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef FieldCodecManager20110405H
 #define FieldCodecManager20110405H
 

--- a/src/field_codec_manager.h
+++ b/src/field_codec_manager.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef FieldCodecManager20110405H
 #define FieldCodecManager20110405H
 

--- a/src/field_codec_typed.h
+++ b/src/field_codec_typed.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLFIELDCODECTYPED20120312H
 #define DCCLFIELDCODECTYPED20120312H
 

--- a/src/field_codec_typed.h
+++ b/src/field_codec_typed.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLFIELDCODECTYPED20120312H
 #define DCCLFIELDCODECTYPED20120312H
 

--- a/src/internal/field_codec_message_stack.cpp
+++ b/src/internal/field_codec_message_stack.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #include "field_codec_message_stack.h"
 #include "dccl/field_codec.h"
 

--- a/src/internal/field_codec_message_stack.cpp
+++ b/src/internal/field_codec_message_stack.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "field_codec_message_stack.h"
 #include "dccl/field_codec.h"
 

--- a/src/internal/field_codec_message_stack.h
+++ b/src/internal/field_codec_message_stack.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLFIELDCODECHELPERS20110825H
 #define DCCLFIELDCODECHELPERS20110825H
 

--- a/src/internal/field_codec_message_stack.h
+++ b/src/internal/field_codec_message_stack.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLFIELDCODECHELPERS20110825H
 #define DCCLFIELDCODECHELPERS20110825H
 

--- a/src/internal/protobuf_cpp_type_helpers.h
+++ b/src/internal/protobuf_cpp_type_helpers.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLPROTOBUFCPPTYPEHELPERS20110323H
 #define DCCLPROTOBUFCPPTYPEHELPERS20110323H
 

--- a/src/internal/protobuf_cpp_type_helpers.h
+++ b/src/internal/protobuf_cpp_type_helpers.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLPROTOBUFCPPTYPEHELPERS20110323H
 #define DCCLPROTOBUFCPPTYPEHELPERS20110323H
 

--- a/src/internal/type_helper.cpp
+++ b/src/internal/type_helper.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "type_helper.h"
 
 dccl::internal::TypeHelper::TypeMap dccl::internal::TypeHelper::type_map_;

--- a/src/internal/type_helper.cpp
+++ b/src/internal/type_helper.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #include "type_helper.h"
 
 dccl::internal::TypeHelper::TypeMap dccl::internal::TypeHelper::type_map_;

--- a/src/internal/type_helper.h
+++ b/src/internal/type_helper.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef TypeHelper20110405H
 #define TypeHelper20110405H
 

--- a/src/internal/type_helper.h
+++ b/src/internal/type_helper.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef TypeHelper20110405H
 #define TypeHelper20110405H
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <ctime>
 
 #include "dccl/logger.h"

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <ctime>
 
 #include "dccl/logger.h"

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 #ifndef DCCLLOGGER20121009H
 #define DCCLLOGGER20121009H
 

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef DCCLLOGGER20121009H
 #define DCCLLOGGER20121009H
 

--- a/src/test/bitset1/test.cpp
+++ b/src/test/bitset1/test.cpp
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <iostream>
 #include <cassert>
 #include <utility>

--- a/src/test/bitset1/test.cpp
+++ b/src/test/bitset1/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <cassert>
 #include <utility>

--- a/src/test/dccl_all_fields/test.cpp
+++ b/src/test/dccl_all_fields/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests all protobuf types with _default codecs, repeat and non repeat
 
 #include <fstream>

--- a/src/test/dccl_all_fields/test.cpp
+++ b/src/test/dccl_all_fields/test.cpp
@@ -1,25 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 // tests all protobuf types with _default codecs, repeat and non repeat
 
 #include <fstream>

--- a/src/test/dccl_arithmetic/test.cpp
+++ b/src/test/dccl_arithmetic/test.cpp
@@ -1,25 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 // tests arithmetic encoder
 
 #include <google/protobuf/descriptor.pb.h>

--- a/src/test/dccl_arithmetic/test.cpp
+++ b/src/test/dccl_arithmetic/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests arithmetic encoder
 
 #include <google/protobuf/descriptor.pb.h>

--- a/src/test/dccl_ccl/test.cpp
+++ b/src/test/dccl_ccl/test.cpp
@@ -1,26 +1,3 @@
-// copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests usage of Legacy CCL
 
 #include <boost/date_time.hpp>

--- a/src/test/dccl_ccl/test.cpp
+++ b/src/test/dccl_ccl/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests usage of Legacy CCL
 
 #include <boost/date_time.hpp>

--- a/src/test/dccl_codec_group/test.cpp
+++ b/src/test/dccl_codec_group/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 // tests all protobuf types with _default codecs, repeat and non repeat
 
 #include <fstream>

--- a/src/test/dccl_codec_group/test.cpp
+++ b/src/test/dccl_codec_group/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests all protobuf types with _default codecs, repeat and non repeat
 
 #include <fstream>

--- a/src/test/dccl_custom_id/test.cpp
+++ b/src/test/dccl_custom_id/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests usage of a custom DCCL ID codec
 
 #include "dccl/codec.h"

--- a/src/test/dccl_custom_id/test.cpp
+++ b/src/test/dccl_custom_id/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests usage of a custom DCCL ID codec
 
 #include "dccl/codec.h"

--- a/src/test/dccl_custom_message/test.cpp
+++ b/src/test/dccl_custom_message/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests custom message codec
 // tests cryptography
 

--- a/src/test/dccl_custom_message/test.cpp
+++ b/src/test/dccl_custom_message/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests custom message codec
 // tests cryptography
 

--- a/src/test/dccl_default_id/test.cpp
+++ b/src/test/dccl_default_id/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests fixed id header
 
 #include "dccl/codec.h"

--- a/src/test/dccl_default_id/test.cpp
+++ b/src/test/dccl_default_id/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests fixed id header
 
 #include "dccl/codec.h"

--- a/src/test/dccl_header/test.cpp
+++ b/src/test/dccl_header/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests proper encoding of standard Goby header
 
 #include "dccl/codec.h"

--- a/src/test/dccl_header/test.cpp
+++ b/src/test/dccl_header/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests proper encoding of standard Goby header
 
 #include "dccl/codec.h"

--- a/src/test/dccl_message_fix/test.cpp
+++ b/src/test/dccl_message_fix/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 // tests all protobuf types with _default codecs, repeat and non repeat
 
 #include <fstream>

--- a/src/test/dccl_message_fix/test.cpp
+++ b/src/test/dccl_message_fix/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests all protobuf types with _default codecs, repeat and non repeat
 
 #include <fstream>

--- a/src/test/dccl_numeric_bounds/test.cpp
+++ b/src/test/dccl_numeric_bounds/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests bounds on DefaultNumericFieldCodec
 
 #include "dccl/codec.h"

--- a/src/test/dccl_numeric_bounds/test.cpp
+++ b/src/test/dccl_numeric_bounds/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests bounds on DefaultNumericFieldCodec
 
 #include "dccl/codec.h"

--- a/src/test/dccl_repeated/test.cpp
+++ b/src/test/dccl_repeated/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests functionality of std::list<const google::protobuf::Message*> calls
 
 

--- a/src/test/dccl_repeated/test.cpp
+++ b/src/test/dccl_repeated/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests functionality of std::list<const google::protobuf::Message*> calls
 
 

--- a/src/test/dccl_required_optional/test.cpp
+++ b/src/test/dccl_required_optional/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests required versus optional encoding of fields using a presence bit
 
 #include "dccl/codec.h"

--- a/src/test/dccl_required_optional/test.cpp
+++ b/src/test/dccl_required_optional/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests required versus optional encoding of fields using a presence bit
 
 #include "dccl/codec.h"

--- a/src/test/dccl_static_methods/test.cpp
+++ b/src/test/dccl_static_methods/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests receiving one of several static types
 
 #include "dccl/codec.h"

--- a/src/test/dccl_static_methods/test.cpp
+++ b/src/test/dccl_static_methods/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests receiving one of several static types
 
 #include "dccl/codec.h"

--- a/src/test/dccl_units/test.cpp
+++ b/src/test/dccl_units/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <iomanip>
 

--- a/src/test/dccl_units/test.cpp
+++ b/src/test/dccl_units/test.cpp
@@ -1,23 +1,3 @@
-// Copyright 2014-2015 Toby Schneider (https://launchpad.net/~tes)
-//                     Stephanie Petillo (https://launchpad.net/~spetillo)
-//                     GobySoft, LLC
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <iostream>
 #include <iomanip>
 

--- a/src/test/dccl_v2_all_fields/test.cpp
+++ b/src/test/dccl_v2_all_fields/test.cpp
@@ -1,26 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 // tests all protobuf types with _default codecs, repeat and non repeat
 
 #include <fstream>

--- a/src/test/dccl_v2_all_fields/test.cpp
+++ b/src/test/dccl_v2_all_fields/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests all protobuf types with _default codecs, repeat and non repeat
 
 #include <fstream>

--- a/src/test/dccl_v2_header/test.cpp
+++ b/src/test/dccl_v2_header/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 // tests proper encoding of standard Goby header
 
 #include "dccl/codec.h"

--- a/src/test/dccl_v2_header/test.cpp
+++ b/src/test/dccl_v2_header/test.cpp
@@ -1,27 +1,3 @@
-// Copyright 2009-2013 Toby Schneider (https://launchpad.net/~tes)
-//                     Massachusetts Institute of Technology (2007-)
-//                     Woods Hole Oceanographic Institution (2007-)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-// 
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
-
 // tests proper encoding of standard Goby header
 
 #include "dccl/codec.h"

--- a/src/test/logger1/test.cpp
+++ b/src/test/logger1/test.cpp
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include "dccl/logger.h"
 
 /// asserts false if called - used for testing proper short-circuiting of logger calls

--- a/src/test/logger1/test.cpp
+++ b/src/test/logger1/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "dccl/logger.h"
 
 /// asserts false if called - used for testing proper short-circuiting of logger calls

--- a/src/test/round1/test.cpp
+++ b/src/test/round1/test.cpp
@@ -1,24 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Applications
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
 #include <iostream>
 #include <cassert>
 #include <utility>

--- a/src/test/round1/test.cpp
+++ b/src/test/round1/test.cpp
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <cassert>
 #include <utility>

--- a/src/version.h
+++ b/src/version.h
@@ -1,25 +1,3 @@
-// Copyright 2009-2014 Toby Schneider (https://launchpad.net/~tes)
-//                     GobySoft, LLC (2013-)
-//                     Massachusetts Institute of Technology (2007-2014)
-//                     DCCL Developers Team (https://launchpad.net/~dccl-dev)
-//
-// This file is part of the Dynamic Compact Control Language Library
-// ("DCCL").
-//
-// DCCL is free software: you can redistribute them and/or modify
-// them under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or
-// (at your option) any later version.
-//
-// DCCL is distributed in the hope that they will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-
-
 #ifndef VERSION20110304H
 #define VERSION20110304H
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,3 +1,24 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef VERSION20110304H
 #define VERSION20110304H
 


### PR DESCRIPTION
- Consistency of headers
- Separate preamble for code developed only by GobySoft (not MIT)
- Updated year
- Updated authors file.
