### PR TITLE
Fixes file not found when passing relative paths including ".." to the dccl tool

### DIFF
--- a/src/apps/dccl/dccl_tool.cpp
+++ b/src/apps/dccl/dccl_tool.cpp
@@ -43,6 +43,11 @@
 #include "dccl_tool.pb.h"
 #include "dccl/version.h"
 
+// for realpath
+#include <limits.h>
+#include <stdlib.h>
+
+
 enum Action { NO_ACTION, ENCODE, DECODE, ANALYZE, DISP_PROTO };
 enum Format { BINARY, TEXTFORMAT, HEX, BASE64 };
 
@@ -445,7 +450,21 @@ void parse_options(int argc, char* argv[], dccl::tool::Config* cfg)
             case 'I': cfg->include.insert(optarg); break;
             case 'l': cfg->dlopen.push_back(optarg); break;
             case 'm': cfg->message.insert(optarg); break;
-            case 'f': cfg->proto_file.insert(optarg); break;                
+            case 'f':
+            {
+                char* proto_file_canonical_path = realpath(optarg, 0);
+                if(proto_file_canonical_path)
+                {
+                    cfg->proto_file.insert(proto_file_canonical_path);
+                    free(proto_file_canonical_path);
+                }
+                else
+                {
+                    std::cerr << "Invalid proto file path: '" << optarg << "'" << std::endl;
+                    exit(EXIT_FAILURE);
+                }
+                break;
+            }
             case 'i': cfg->id_codec = optarg; break;                
             case 'v': cfg->verbose = true; break;                
             case 'o': cfg->omit_prefix = true; break;                


### PR DESCRIPTION
Bug is that --proto_file arguments with relative ".." path components are not found even though they exist:

```
./dccl --analyze --proto_file ../src/test/dccl_all_fields/test.proto
terminate called after throwing an instance of 'dccl::Exception'
  what():  File: ../src/test/dccl_all_fields/test.proto has error (line: -1, column: 0):File not found.
zsh: abort (core dumped)  ./dccl --analyze --proto_file ../src/test/dccl_all_fields/test.proto
```

This pull request fixes that by canonicalizing the --proto_file (-f) arguments before passing to the DynamicProtobufManager (which passes them to libprotoc).

```
 ./dccl --analyze --proto_file ../src/test/dccl_all_fields/test.proto
...
||||||| Dynamic Compact Control Language (DCCL) Codec |||||||
1 messages loaded.
Field sizes are in bits unless otherwise noted.
==================== 2: dccl.test.TestMsg ====================
...
```
