### PR TITLE
set protobuf message factory to defer to generated factory so that dynamic_cast<>() of dynamic protobuf types should work correctly

### DIFF
--- a/src/dynamic_protobuf_manager.h
+++ b/src/dynamic_protobuf_manager.h
@@ -198,6 +198,8 @@ namespace dccl
                 databases_.push_back(simple_database_); 
                 databases_.push_back(generated_database_);
 
+                msg_factory_->SetDelegateToGeneratedFactory(true);
+
                 merged_database_ = new google::protobuf::MergedDescriptorDatabase(databases_);
                 user_descriptor_pool_ = new google::protobuf::DescriptorPool(merged_database_);
             }


### PR DESCRIPTION
Proposed to fix #6 
