### PR TITLE
Return a useful error when trying to use 'prefix' with an absolute temperature.

### DIFF
--- a/src/apps/pb_plugin/gen_units_class_plugin.h
+++ b/src/apps/pb_plugin/gen_units_class_plugin.h
@@ -362,6 +362,10 @@ inline void construct_units_typedef_from_dimension(const std::string& fieldname,
 
   std::string before;
   std::string after;
+
+  if(absolute && !prefix.empty())
+      throw(std::runtime_error(std::string("'prefix' is not supported with an absolute temperature field")));
+  
   if(absolute)
       add_absolute(before, after);  
 

--- a/src/test/dccl_units/test.cpp
+++ b/src/test/dccl_units/test.cpp
@@ -60,6 +60,7 @@ int main()
     std::cout << temp_d << std::endl;
 
     test_msg.set_temperature_with_units(15*absolute<fahrenheit::temperature>());
+    test_msg.set_micro_temp_with_units(15*Kelvin());
     test_msg.set_salinity(35.2);
     test_msg.set_sound_speed(1500);
 
@@ -75,6 +76,7 @@ int main()
     
     std::cout << test_msg.DebugString() << std::endl; //outputs protobuf debug string
     std::cout << "Temperature: " << test_msg.temperature_with_units() << std::endl;
+    std::cout << "Micro temperature: " << test_msg.micro_temp_with_units() << std::endl;
     std::cout <<std::setprecision(10) << "Pressure: " << test_msg.pressure_with_units() << std::endl;
     std::cout << "Pressure (as bars): " << quantity<Bar>(test_msg.pressure_with_units()) << std::endl;
     std::cout << "Sound speed: " << test_msg.sound_speed_with_units() << std::endl;

--- a/src/test/dccl_units/test.proto
+++ b/src/test/dccl_units/test.proto
@@ -12,7 +12,16 @@ message CTDTestMessage
                                                     min: 0
                                                     max: 30
                                                     precision: -1 }];
-  required int32 pressure = 4 [(dccl.field).units.derived_dimensions = "pressure"];
+
+    required double micro_temp = 5 [(dccl.field) = { units { base_dimensions: "K"
+                                                             prefix: "micro"
+                                                             relative_temperature: true
+            }
+                                                     min: 0
+                                                     max: 30
+                                                     precision: -1 }];
+
+    required int32 pressure = 4 [(dccl.field).units.derived_dimensions = "pressure"];
   
   required double salinity = 10 [(dccl.field).units.base_dimensions = "-"]; 
   required double sound_speed = 11 [(dccl.field).units.base_dimensions = " LT^-1"]; 


### PR DESCRIPTION
Also, added test for using a prefix with relative temperature (which does work).

Fixes #25 