### PR TITLE
Strict mode

### DIFF
--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -204,6 +204,11 @@ void dccl::Codec::encode_internal(const google::protobuf::Message& msg, bool hea
         }
         
     }
+    catch(dccl::OutOfRangeException& e)
+    {
+        dlog.is(DEBUG1, ENCODE) && dlog << "Message " << desc->full_name() << " failed to encode because a field was out of bounds and strict == true: " << e.what() << std::endl;
+        throw;
+    }
     catch(std::exception& e)
     {
         std::stringstream ss;

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -65,7 +65,7 @@ const unsigned full_width = 60;
 //
 
 dccl::Codec::Codec(const std::string& dccl_id_codec, const std::string& library_path)
-    : id_codec_(dccl_id_codec)
+    : id_codec_(dccl_id_codec), strict_(false)
 {
     set_default_codecs();
     FieldCodecManager::add<DefaultIdentifierCodec>(default_id_codec_name());
@@ -183,7 +183,7 @@ void dccl::Codec::encode_internal(const google::protobuf::Message& msg, bool hea
             
             internal::MessageStack msg_stack;
             msg_stack.push(msg.GetDescriptor());
-            codec->base_encode(&head_bits, msg, HEAD);
+            codec->base_encode(&head_bits, msg, HEAD, strict_);
 
             // given header of not even byte size (e.g. 01011), make even byte size (e.g. 00001011)
             head_byte_size = ceil_bits2bytes(head_bits.size());
@@ -195,7 +195,7 @@ void dccl::Codec::encode_internal(const google::protobuf::Message& msg, bool hea
             }
             else
             {
-                codec->base_encode(&body_bits, msg, BODY);
+                codec->base_encode(&body_bits, msg, BODY, strict_);
             }
         }
         else

--- a/src/codec.h
+++ b/src/codec.h
@@ -123,7 +123,13 @@ namespace dccl
         /// \param do_not_encrypt_ids_ Optional set of DCCL ids for which to skip encrypting or decrypting
         void set_crypto_passphrase(const std::string& passphrase,
                                    const std::set<unsigned>& do_not_encrypt_ids_ = std::set<unsigned>());
-            
+
+        
+        /// \brief Set "strict" mode where a dccl::OutOfRangeException will be thrown for encode if the value(s) provided are out of range
+        ///
+        /// \param mode "true" sets strict mode, "false" disables strict mode
+        void set_strict(bool mode) { strict_ = mode; }
+        
         //@}
             
         /// \name Informational Methods.
@@ -331,6 +337,9 @@ namespace dccl
         // SHA256 hash of the crypto passphrase
         std::string crypto_key_;
 
+        // strict mode setting
+        bool strict_;
+        
 	// set of DCCL IDs *not* to encrypt        
 	std::set<unsigned> skip_crypto_ids_;
 

--- a/src/codecs2/field_codec_default.cpp
+++ b/src/codecs2/field_codec_default.cpp
@@ -88,6 +88,9 @@ dccl::Bitset dccl::v2::DefaultStringCodec::encode(const std::string& wire_value)
     std::string s = wire_value;
     if(s.size() > dccl_field_options().max_length())
     {
+        if(this->strict())
+            throw(dccl::OutOfRangeException(std::string("String too long for field: ") + FieldCodecBase::this_field()->DebugString()));
+        
         dccl::dlog.is(DEBUG2) && dccl::dlog << "String " << s <<  " exceeds `dccl.max_length`, truncating" << std::endl;
         s.resize(dccl_field_options().max_length()); 
     }

--- a/src/codecs2/field_codec_default.cpp
+++ b/src/codecs2/field_codec_default.cpp
@@ -89,7 +89,7 @@ dccl::Bitset dccl::v2::DefaultStringCodec::encode(const std::string& wire_value)
     if(s.size() > dccl_field_options().max_length())
     {
         if(this->strict())
-            throw(dccl::OutOfRangeException(std::string("String too long for field: ") + FieldCodecBase::this_field()->DebugString()));
+            throw(dccl::OutOfRangeException(std::string("String too long for field: ") + FieldCodecBase::this_field()->DebugString(), this->this_field()));
         
         dccl::dlog.is(DEBUG2) && dccl::dlog << "String " << s <<  " exceeds `dccl.max_length`, truncating" << std::endl;
         s.resize(dccl_field_options().max_length()); 
@@ -192,7 +192,7 @@ dccl::Bitset dccl::v2::DefaultBytesCodec::encode(const std::string& wire_value)
     bits.from_byte_string(wire_value);
 
     if(bits.size() > max_size() && this->strict())
-        throw(dccl::OutOfRangeException(std::string("Bytes too long for field: ") + FieldCodecBase::this_field()->DebugString()));
+        throw(dccl::OutOfRangeException(std::string("Bytes too long for field: ") + FieldCodecBase::this_field()->DebugString(), this->this_field()));
     
     bits.resize(max_size());
     

--- a/src/codecs2/field_codec_default.cpp
+++ b/src/codecs2/field_codec_default.cpp
@@ -190,6 +190,10 @@ dccl::Bitset dccl::v2::DefaultBytesCodec::encode(const std::string& wire_value)
 {
     Bitset bits;
     bits.from_byte_string(wire_value);
+
+    if(bits.size() > max_size() && this->strict())
+        throw(dccl::OutOfRangeException(std::string("Bytes too long for field: ") + FieldCodecBase::this_field()->DebugString()));
+    
     bits.resize(max_size());
     
     if(!use_required())

--- a/src/codecs2/field_codec_default.h
+++ b/src/codecs2/field_codec_default.h
@@ -102,9 +102,16 @@ namespace dccl
                   // round first, before checking bounds
                   WireType wire_value = dccl::round(value, precision());
 
-                  // check bounds, if out-of-bounds, send as zeros
+                  // check bounds
                   if(wire_value < min() || wire_value > max())
-                      return Bitset(size());
+                  {
+                      // strict mode
+                      if(this->strict())
+                          throw(dccl::OutOfRangeException(std::string("Value exceeds min/max bounds for field: ") + FieldCodecBase::this_field()->DebugString()));
+                      // non-strict (default): if out-of-bounds, send as zeros
+                      else
+                          return Bitset(size());
+                  }
           
                   wire_value -= dccl::round((WireType)min(), precision());
 

--- a/src/codecs2/field_codec_default.h
+++ b/src/codecs2/field_codec_default.h
@@ -107,7 +107,7 @@ namespace dccl
                   {
                       // strict mode
                       if(this->strict())
-                          throw(dccl::OutOfRangeException(std::string("Value exceeds min/max bounds for field: ") + FieldCodecBase::this_field()->DebugString()));
+                          throw(dccl::OutOfRangeException(std::string("Value exceeds min/max bounds for field: ") + FieldCodecBase::this_field()->DebugString(), this->this_field()));
                       // non-strict (default): if out-of-bounds, send as zeros
                       else
                           return Bitset(size());

--- a/src/codecs3/field_codec_default.cpp
+++ b/src/codecs3/field_codec_default.cpp
@@ -37,6 +37,9 @@ dccl::Bitset dccl::v3::DefaultStringCodec::encode(const std::string& wire_value)
     std::string s = wire_value;
     if(s.size() > dccl_field_options().max_length())
     {
+        if(this->strict())
+            throw(dccl::OutOfRangeException(std::string("String too long for field: ") + FieldCodecBase::this_field()->DebugString()));
+                
         dccl::dlog.is(DEBUG2) && dccl::dlog << "String " << s <<  " exceeds `dccl.max_length`, truncating" << std::endl;
         s.resize(dccl_field_options().max_length()); 
     }

--- a/src/codecs3/field_codec_default.cpp
+++ b/src/codecs3/field_codec_default.cpp
@@ -38,7 +38,7 @@ dccl::Bitset dccl::v3::DefaultStringCodec::encode(const std::string& wire_value)
     if(s.size() > dccl_field_options().max_length())
     {
         if(this->strict())
-            throw(dccl::OutOfRangeException(std::string("String too long for field: ") + FieldCodecBase::this_field()->DebugString()));
+            throw(dccl::OutOfRangeException(std::string("String too long for field: ") + FieldCodecBase::this_field()->DebugString(), this->this_field()));
                 
         dccl::dlog.is(DEBUG2) && dccl::dlog << "String " << s <<  " exceeds `dccl.max_length`, truncating" << std::endl;
         s.resize(dccl_field_options().max_length()); 

--- a/src/codecs3/field_codec_var_bytes.cpp
+++ b/src/codecs3/field_codec_var_bytes.cpp
@@ -16,6 +16,9 @@ dccl::Bitset dccl::v3::VarBytesCodec::encode(const std::string& wire_value)
     std::string s = wire_value;
     if(s.size() > dccl_field_options().max_length())
     {
+        if(this->strict())
+            throw(dccl::OutOfRangeException(std::string("Bytes too long for field: ") + FieldCodecBase::this_field()->DebugString()));
+        
         dccl::dlog.is(DEBUG2) && dccl::dlog << "Bytes " << s <<  " exceeds `dccl.max_length`, truncating" << std::endl;
         s.resize(dccl_field_options().max_length()); 
     }

--- a/src/codecs3/field_codec_var_bytes.cpp
+++ b/src/codecs3/field_codec_var_bytes.cpp
@@ -17,7 +17,7 @@ dccl::Bitset dccl::v3::VarBytesCodec::encode(const std::string& wire_value)
     if(s.size() > dccl_field_options().max_length())
     {
         if(this->strict())
-            throw(dccl::OutOfRangeException(std::string("Bytes too long for field: ") + FieldCodecBase::this_field()->DebugString()));
+            throw(dccl::OutOfRangeException(std::string("Bytes too long for field: ") + FieldCodecBase::this_field()->DebugString(), this->this_field()));
         
         dccl::dlog.is(DEBUG2) && dccl::dlog << "Bytes " << s <<  " exceeds `dccl.max_length`, truncating" << std::endl;
         s.resize(dccl_field_options().max_length()); 

--- a/src/exception.h
+++ b/src/exception.h
@@ -43,9 +43,14 @@ namespace dccl
           : Exception("NULL Value")
         { }    
     };
-        
-}
 
+    class OutOfRangeException : public std::out_of_range
+    {
+      public:
+      OutOfRangeException(const std::string& s) : std::out_of_range(s)
+        { }
+    };
+}
 
 #endif
 

--- a/src/exception.h
+++ b/src/exception.h
@@ -23,6 +23,7 @@
 #define Exception20100812H
 
 #include <stdexcept>
+#include <google/protobuf/descriptor.h>
 
 namespace dccl
 {
@@ -47,8 +48,13 @@ namespace dccl
     class OutOfRangeException : public std::out_of_range
     {
       public:
-      OutOfRangeException(const std::string& s) : std::out_of_range(s)
+        OutOfRangeException(const std::string& s, const google::protobuf::FieldDescriptor* field) : std::out_of_range(s), field_(field)
         { }
+
+        const google::protobuf::FieldDescriptor* field() const { return field_; }
+        
+    private:
+        const google::protobuf::FieldDescriptor* field_;
     };
 }
 

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -28,6 +28,8 @@
 dccl::MessagePart dccl::FieldCodecBase::part_ =
     dccl::UNKNOWN;
 
+bool dccl::FieldCodecBase::strict_ = false;
+
 const google::protobuf::Message* dccl::FieldCodecBase::root_message_ = 0;
 const google::protobuf::Descriptor* dccl::FieldCodecBase::root_descriptor_ = 0;
 
@@ -41,9 +43,10 @@ dccl::FieldCodecBase::FieldCodecBase() { }
             
 void dccl::FieldCodecBase::base_encode(Bitset* bits,
                                        const google::protobuf::Message& field_value,
-                                       MessagePart part)
+                                       MessagePart part,
+                                       bool strict)
 {
-    BaseRAII scoped_globals(part, &field_value);
+    BaseRAII scoped_globals(part, &field_value, strict);
 
     // we pass this through the FromProtoCppTypeBase to do dynamic_cast (RTTI) for
     // custom message codecs so that these codecs can be written in the derived class (not google::protobuf::Message)

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -388,7 +388,10 @@ void dccl::FieldCodecBase::any_encode_repeated(dccl::Bitset* bits, const std::ve
 
     unsigned wire_vector_size = dccl_field_options().max_repeat();
 
-    // for DCCL3 and beyond, add a prefix numeric field giving the vector size (rather than always going to max_repeat
+    if(wire_values.size() > wire_vector_size)
+        throw(dccl::OutOfRangeException(std::string("Repeated size exceeds max_repeat for field: ") + FieldCodecBase::this_field()->DebugString(), this->this_field()));
+    
+    // for DCCL3 and beyond, add a prefix numeric field giving the vector size (rather than always going to max_repeat)
     if(codec_version() > 2)
     {
         wire_vector_size = std::min((int)dccl_field_options().max_repeat(), (int)wire_values.size());    

--- a/src/field_codec.h
+++ b/src/field_codec.h
@@ -116,7 +116,10 @@ namespace dccl
             
         /// \brief the part of the message currently being encoded (head or body).
         static MessagePart part() { return part_; }
-            
+
+        static bool strict() { return strict_; }
+        
+        
         //@}
 
         /// \name Base message functions
@@ -138,7 +141,8 @@ namespace dccl
         /// \param part Part of the message to encode
         void base_encode(Bitset* bits,
                          const google::protobuf::Message& msg,
-                         MessagePart part);
+                         MessagePart part,
+                         bool strict);
 
         /// \brief Calculate the size (in bits) of a part of the base message when it is encoded
         ///
@@ -454,23 +458,28 @@ namespace dccl
         struct BaseRAII
         {
             BaseRAII(MessagePart part,
-                     const google::protobuf::Descriptor* root_descriptor)
+                     const google::protobuf::Descriptor* root_descriptor,
+                     bool strict = false)
                 {
                     FieldCodecBase::part_ = part;
+                    FieldCodecBase::strict_ = strict;
                     FieldCodecBase::root_message_ = 0;
                     FieldCodecBase::root_descriptor_ = root_descriptor;
                 }
 
             BaseRAII(MessagePart part,            
-                     const google::protobuf::Message* root_message)
+                     const google::protobuf::Message* root_message,
+                     bool strict = false)                
                 {
                     FieldCodecBase::part_ = part;
+                    FieldCodecBase::strict_ = strict;
                     FieldCodecBase::root_message_ = root_message;
                     FieldCodecBase::root_descriptor_ = root_message->GetDescriptor();                    
                 }
             ~BaseRAII()
                 {
                     FieldCodecBase::part_ = dccl::UNKNOWN;
+                    FieldCodecBase::strict_ = false;
                     FieldCodecBase::root_message_ = 0;
                     FieldCodecBase::root_descriptor_ = 0;
                 }
@@ -478,6 +487,7 @@ namespace dccl
         
         
         static MessagePart part_;
+        static bool strict_;
         static const google::protobuf::Message* root_message_;
         static const google::protobuf::Descriptor* root_descriptor_;
         

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(dccl_custom_id)
 add_subdirectory(dccl_numeric_bounds)
 add_subdirectory(dccl_codec_group)
 add_subdirectory(dccl_message_fix)
+add_subdirectory(dccl_strict)
 
 if(enable_units)
   add_subdirectory(dccl_units)

--- a/src/test/dccl_strict/CMakeLists.txt
+++ b/src/test/dccl_strict/CMakeLists.txt
@@ -1,0 +1,6 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test.proto)
+
+add_executable(dccl_test_strict test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(dccl_test_strict dccl)
+
+add_test(dccl_test_strict ${dccl_BIN_DIR}/dccl_test_strict)

--- a/src/test/dccl_strict/test.cpp
+++ b/src/test/dccl_strict/test.cpp
@@ -69,6 +69,7 @@ int main(int argc, char* argv[])
     }
     catch(dccl::OutOfRangeException& e)
     {
+        assert(e.field() == TestMsg::descriptor()->FindFieldByName("d"));
         std::cout << "Caught (as expected) " << e.what() << std::endl;
     }
     
@@ -87,6 +88,7 @@ int main(int argc, char* argv[])
     }
     catch(dccl::OutOfRangeException& e)
     {
+        assert(e.field() == TestMsg::descriptor()->FindFieldByName("i"));
         std::cout << "Caught (as expected) " << e.what() << std::endl;
     }
 
@@ -105,6 +107,7 @@ int main(int argc, char* argv[])
     }
     catch(dccl::OutOfRangeException& e)
     {
+        assert(e.field() == TestMsg::descriptor()->FindFieldByName("s2"));
         std::cout << "Caught (as expected) " << e.what() << std::endl;
     }
 
@@ -123,6 +126,7 @@ int main(int argc, char* argv[])
     }
     catch(dccl::OutOfRangeException& e)
     {
+        assert(e.field() == TestMsg::descriptor()->FindFieldByName("s"));
         std::cout << "Caught (as expected) " << e.what() << std::endl;
     }
 
@@ -141,6 +145,7 @@ int main(int argc, char* argv[])
     }
     catch(dccl::OutOfRangeException& e)
     {
+        assert(e.field() == TestMsg::descriptor()->FindFieldByName("b"));
         std::cout << "Caught (as expected) " << e.what() << std::endl;
     }
     
@@ -159,6 +164,7 @@ int main(int argc, char* argv[])
     }
     catch(dccl::OutOfRangeException& e)
     {
+        assert(e.field() == TestMsg::descriptor()->FindFieldByName("vb"));
         std::cout << "Caught (as expected) " << e.what() << std::endl;
     }
     

--- a/src/test/dccl_strict/test.cpp
+++ b/src/test/dccl_strict/test.cpp
@@ -49,6 +49,9 @@ int main(int argc, char* argv[])
         msg_in.set_i(1000);
         msg_in.set_s("foo");
         msg_in.set_b(std::string(9, '1'));
+        msg_in.add_ri(1);
+        msg_in.add_ri(2);
+        msg_in.add_ri(3);
         
         decode_check(msg_in);
     }
@@ -168,7 +171,29 @@ int main(int argc, char* argv[])
         std::cout << "Caught (as expected) " << e.what() << std::endl;
     }
     
-    
+
+    // repeat size out of range
+    try
+    {
+        TestMsg msg_in;
+        msg_in.set_d(10.0);
+        msg_in.set_i(1000);
+        msg_in.set_s("foo");
+        msg_in.set_b(std::string(9, '1'));
+        msg_in.add_ri(1);
+        msg_in.add_ri(2);
+        msg_in.add_ri(3);
+        msg_in.add_ri(4);
+        
+        decode_check(msg_in);
+    }
+    catch(dccl::OutOfRangeException& e)
+    {
+        assert(e.field() == TestMsg::descriptor()->FindFieldByName("ri"));
+        std::cout << "Caught (as expected) " << e.what() << std::endl;
+    }
+
+
     std::cout << "all tests passed" << std::endl;
 }
 

--- a/src/test/dccl_strict/test.cpp
+++ b/src/test/dccl_strict/test.cpp
@@ -1,0 +1,188 @@
+// Copyright 2009-2017 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
+// tests all protobuf types with _default codecs, repeat and non repeat
+
+#include <fstream>
+
+#include <google/protobuf/descriptor.pb.h>
+
+#include "dccl/codec.h"
+#include "test.pb.h"
+#include "dccl/binary.h"
+using namespace dccl::test;
+
+void decode_check(const TestMsg& msg_in);
+dccl::Codec codec;
+
+int main(int argc, char* argv[])
+{
+    dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
+
+    codec.info<TestMsg>();
+    codec.load<TestMsg>();
+
+    // enable strict mode
+    codec.set_strict(true);
+
+    {
+        TestMsg msg_in;
+        msg_in.set_d(10.0);
+        msg_in.set_i(1000);
+        msg_in.set_s("foo");
+        msg_in.set_b(std::string(9, '1'));
+        
+        decode_check(msg_in);
+    }
+
+
+    // double out of range
+    try
+    {
+        TestMsg msg_in;
+        msg_in.set_d(150);
+        msg_in.set_i(1000);
+        msg_in.set_s("foo");
+        msg_in.set_b(std::string(9, '1'));
+        
+        decode_check(msg_in);
+        bool expected_out_of_range_exception = false;
+        assert(expected_out_of_range_exception);
+    }
+    catch(dccl::OutOfRangeException& e)
+    {
+        std::cout << "Caught (as expected) " << e.what() << std::endl;
+    }
+    
+    // int out of range
+    try
+    {
+        TestMsg msg_in;
+        msg_in.set_d(10.0);
+        msg_in.set_i(-30);
+        msg_in.set_s("foo");
+        msg_in.set_b(std::string(9, '1'));
+        
+        decode_check(msg_in);
+        bool expected_out_of_range_exception = false;
+        assert(expected_out_of_range_exception);
+    }
+    catch(dccl::OutOfRangeException& e)
+    {
+        std::cout << "Caught (as expected) " << e.what() << std::endl;
+    }
+
+    // string (version 2) out of range
+    try
+    {
+        TestMsg msg_in;
+        msg_in.set_d(10.0);
+        msg_in.set_i(1000);
+        msg_in.set_s2("foobar1234546789");
+        msg_in.set_b(std::string(9, '1'));
+        
+        decode_check(msg_in);
+        bool expected_out_of_range_exception = false;
+        assert(expected_out_of_range_exception);
+    }
+    catch(dccl::OutOfRangeException& e)
+    {
+        std::cout << "Caught (as expected) " << e.what() << std::endl;
+    }
+
+    // string (version 3) out of range
+    try
+    {
+        TestMsg msg_in;
+        msg_in.set_d(10.0);
+        msg_in.set_i(1000);
+        msg_in.set_s("foobar1234546789");
+        msg_in.set_b(std::string(9, '1'));
+        
+        decode_check(msg_in);
+        bool expected_out_of_range_exception = false;
+        assert(expected_out_of_range_exception);
+    }
+    catch(dccl::OutOfRangeException& e)
+    {
+        std::cout << "Caught (as expected) " << e.what() << std::endl;
+    }
+
+    // bytes out of range
+    try
+    {
+        TestMsg msg_in;
+        msg_in.set_d(10.0);
+        msg_in.set_i(1000);
+        msg_in.set_s("foo");
+        msg_in.set_b(std::string(12, '1'));
+        
+        decode_check(msg_in);
+        bool expected_out_of_range_exception = false;
+        assert(expected_out_of_range_exception);
+    }
+    catch(dccl::OutOfRangeException& e)
+    {
+        std::cout << "Caught (as expected) " << e.what() << std::endl;
+    }
+    
+    // var bytes out of range
+    try
+    {
+        TestMsg msg_in;
+        msg_in.set_d(10.0);
+        msg_in.set_i(1000);
+        msg_in.set_s("foo");
+        msg_in.set_vb(std::string(12, '1'));
+        
+        decode_check(msg_in);
+        bool expected_out_of_range_exception = false;
+        assert(expected_out_of_range_exception);
+    }
+    catch(dccl::OutOfRangeException& e)
+    {
+        std::cout << "Caught (as expected) " << e.what() << std::endl;
+    }
+    
+    
+    std::cout << "all tests passed" << std::endl;
+}
+
+
+void decode_check(const TestMsg& msg_in)
+{
+    
+    std::cout << "Message in:\n" << msg_in.DebugString() << std::endl;
+    
+    std::cout << "Try encode (in bounds)..." << std::endl;
+    std::string bytes;
+    codec.encode(&bytes, msg_in);
+    std::cout << "... got bytes (hex): " << dccl::hex_encode(bytes) << std::endl;
+    
+    std::cout << "Try decode..." << std::endl;
+        
+    TestMsg msg_out;
+    codec.decode(bytes, &msg_out);
+    
+    std::cout << "... got Message out:\n" << msg_out.DebugString() << std::endl;
+
+    assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
+}

--- a/src/test/dccl_strict/test.proto
+++ b/src/test/dccl_strict/test.proto
@@ -22,5 +22,9 @@ message TestMsg
     optional bytes b = 15 [(dccl.field).max_length=9];
     optional bytes vb = 16 [(dccl.field).max_length=9,
                             (dccl.field).codec="dccl.var_bytes"];
+
+    repeated int32 ri = 17 [(dccl.field).min=-20,
+                           (dccl.field).max=3000,
+                           (dccl.field).max_repeat=3];
 }
 

--- a/src/test/dccl_strict/test.proto
+++ b/src/test/dccl_strict/test.proto
@@ -1,0 +1,26 @@
+@PROTOBUF_SYNTAX_VERSION@
+import "dccl/option_extensions.proto";
+
+package dccl.test;
+
+message TestMsg
+{
+  option (dccl.msg).id = 2;
+  option (dccl.msg).max_bytes = 64;
+  option (dccl.msg).codec_version = 3;
+
+    // test default enc/dec
+    required double d = 1 [(dccl.field).min=-100,
+                           (dccl.field).max=126,
+                           (dccl.field).precision=2,
+                           (dccl.field).in_head=true];
+    optional int32 i = 3 [(dccl.field).min=-20,
+                                               (dccl.field).max=3000];
+    optional string s2 = 13 [(dccl.field).max_length=8,
+                             (dccl.field).codec="dccl.default2"];
+    optional string s = 14 [(dccl.field).max_length=8];
+    optional bytes b = 15 [(dccl.field).max_length=9];
+    optional bytes vb = 16 [(dccl.field).max_length=9,
+                            (dccl.field).codec="dccl.var_bytes"];
+}
+


### PR DESCRIPTION
Adds optional "strict mode" for default codecs to throw `dccl::OutOfRangeException` if fields are out of bounds at encode time.

To enable:
```
dccl::Codec codec;
codec.set_strict(true);
```
To disable (also the default)
```
codec.set_strict(false);
```

The codecs that support strict mode are given in `src/test/dccl_strict/test.proto` and should include all the default version 2 and 3 codecs that could be given out of bounds (that is all but enum, bool which are inherently bounded).