### PR TITLE
Set BUFFERSIZE macro used by libb64

### DIFF
--- a/src/binary.h
+++ b/src/binary.h
@@ -31,6 +31,8 @@
 #define DCCL_HAS_B64 @DCCL_HAS_B64@
 
 #if DCCL_HAS_B64
+#include <cstdio>
+#define BUFFERSIZE BUFSIZ
 #include "b64/encode.h"
 #include "b64/decode.h"
 #endif


### PR DESCRIPTION
See http://sourceforge.net/tracker/?func=detail&atid=785907&aid=3591336&group_id=152942

Fixes #43 