### PR TITLE
Adding packed_enum option (fixes #45)

### DIFF
--- a/src/codecs3/field_codec_default.cpp
+++ b/src/codecs3/field_codec_default.cpp
@@ -123,3 +123,67 @@ void dccl::v3::DefaultStringCodec::validate()
 {
     require(dccl_field_options().has_max_length(), "missing (dccl.field).max_length");
 }
+
+//
+// DefaultEnumCodec
+//
+double dccl::v3::DefaultEnumCodec::max()
+{
+    const google::protobuf::EnumDescriptor* e = this_field()->enum_type();
+
+    if (dccl_field_options().packed_enum()) {
+        return e->value_count()-1;
+    } else {
+        const google::protobuf::EnumValueDescriptor* value = e->value(0);
+        int32 maxVal = value->number();
+        for (int i=1; i < e->value_count(); ++i) {
+            value = e->value(i);
+            if (value->number() > maxVal) { maxVal = value->number(); }
+        }
+        return maxVal;
+    }
+}
+
+double dccl::v3::DefaultEnumCodec::min()
+{
+    if (dccl_field_options().packed_enum()) {
+        return 0;
+    } else {
+        const google::protobuf::EnumDescriptor* e = this_field()->enum_type();
+        const google::protobuf::EnumValueDescriptor* value = e->value(0);
+        int32 minVal = value->number();
+        for (int i=1; i < e->value_count(); ++i) {
+            value = e->value(i);
+            if (value->number() < minVal) { minVal = value->number(); }
+        }
+        return minVal;
+    }
+}
+
+dccl::int32 dccl::v3::DefaultEnumCodec::pre_encode(const google::protobuf::EnumValueDescriptor* const& field_value)
+{
+    if (dccl_field_options().packed_enum())
+        return field_value->index();
+    else
+        return field_value->number();
+}
+
+const google::protobuf::EnumValueDescriptor* dccl::v3::DefaultEnumCodec::post_decode(const dccl::int32& wire_value)
+{
+    const google::protobuf::EnumDescriptor* e = this_field()->enum_type();
+
+    if (dccl_field_options().packed_enum()) {
+        if(wire_value < e->value_count()) {
+            const google::protobuf::EnumValueDescriptor* return_value = e->value(wire_value);
+            return return_value;
+        }
+        else
+            throw NullValueException();
+    } else {
+        const google::protobuf::EnumValueDescriptor* return_value = e->FindValueByNumber(wire_value);
+        if(return_value != NULL)
+            return return_value;
+        else
+            throw NullValueException();
+    }
+}

--- a/src/codecs3/field_codec_default.h
+++ b/src/codecs3/field_codec_default.h
@@ -35,10 +35,29 @@ namespace dccl
         template<typename WireType, typename FieldType = WireType>
             class DefaultNumericFieldCodec : public v2::DefaultNumericFieldCodec<WireType, FieldType> { };
 
-	typedef v2::DefaultBoolCodec DefaultBoolCodec;
-	typedef v2::DefaultBytesCodec DefaultBytesCodec;
-        typedef v2::DefaultEnumCodec DefaultEnumCodec;
+        typedef v2::DefaultBoolCodec DefaultBoolCodec;
+        typedef v2::DefaultBytesCodec DefaultBytesCodec;
+        // Enum Codec is identical to v2, except when packed_enum is set to false.
 
+        /// \brief Provides an enum encoder. This converts the enumeration to an integer and uses
+        /// DefaultNumericFieldCodec to encode the integer.  Note that by default, the value is
+        /// based on the enumeration <i>index</i> (<b>not</b> its <i>value</i>.  If you wish to 
+        /// allocate space for all values between a lower and upper bound (for future expansion
+        /// of the enumeration values, for instance) then set the (dccl.field).packed_enum
+        /// extension to false.  The enumerate value will then be used for encoding.
+        class DefaultEnumCodec
+            : public DefaultNumericFieldCodec<int32, const google::protobuf::EnumValueDescriptor*>
+        {
+          public:
+            int32 pre_encode(const google::protobuf::EnumValueDescriptor* const& field_value);
+            const google::protobuf::EnumValueDescriptor* post_decode(const int32& wire_value);
+
+          private:
+            void validate() { }
+            
+            double max();
+            double min();
+        };
         
         template<typename TimeType>
             class TimeCodec : public v2::TimeCodecBase<TimeType, 0>

--- a/src/option_extensions.proto
+++ b/src/option_extensions.proto
@@ -51,6 +51,9 @@ message DCCLFieldOptions
   // any `repeated` field
   optional uint32 max_repeat = 10 [default = 1];
 
+  // enum
+  optional bool packed_enum = 11 [default = true];
+
   optional string description = 20;
 
   message Units

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(dccl_numeric_bounds)
 add_subdirectory(dccl_codec_group)
 add_subdirectory(dccl_message_fix)
 add_subdirectory(dccl_strict)
+add_subdirectory(dccl_packed_enum)
 
 if(enable_units)
   add_subdirectory(dccl_units)

--- a/src/test/dccl_packed_enum/CMakeLists.txt
+++ b/src/test/dccl_packed_enum/CMakeLists.txt
@@ -1,0 +1,6 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test.proto)
+
+add_executable(dccl_test_packed_enum test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(dccl_test_packed_enum dccl)
+
+add_test(dccl_test_packed_enum ${dccl_BIN_DIR}/dccl_test_packed_enum)

--- a/src/test/dccl_packed_enum/test.cpp
+++ b/src/test/dccl_packed_enum/test.cpp
@@ -1,0 +1,69 @@
+// Copyright 2009-2017 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
+// tests all protobuf types with _default codecs, repeat and non repeat
+
+#include <google/protobuf/descriptor.pb.h>
+
+#include "dccl/codecs3/field_codec_default.h"
+#include "dccl/codec.h"
+#include "test.pb.h"
+#include "dccl/binary.h"
+using namespace dccl::test;
+
+void decode_check(const std::string& encoded);
+
+dccl::Codec codec;
+TestMsgPack msg_pack;
+TestMsgUnpack msg_unpack;
+
+int main(int argc, char* argv[]) {
+    dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
+
+    msg_pack.set_five_bit_padding(0);
+    msg_pack.set_value(ENUM2_H);
+    msg_unpack.set_value(ENUM2_H);
+
+    codec.info(msg_pack.GetDescriptor());
+    codec.info(msg_unpack.GetDescriptor());
+
+    codec.load(msg_pack.GetDescriptor());
+    codec.load(msg_unpack.GetDescriptor());
+
+    std::cout << "Try encode..." << std::endl;
+    std::string bytes_pack;
+    codec.encode(&bytes_pack, msg_pack);
+    std::cout << "... got packed bytes (hex): " << dccl::hex_encode(bytes_pack) << std::endl;
+
+    std::string bytes_unpack;
+    codec.encode(&bytes_unpack, msg_unpack);
+    std::cout << "... got unpacked bytes (hex): " << dccl::hex_encode(bytes_unpack) << std::endl;
+
+    std::cout << "Try decode..." << std::endl;
+    TestMsgPack msg_pack_out;
+    TestMsgUnpack msg_unpack_out;
+
+    codec.decode(bytes_pack, &msg_pack_out);
+    codec.decode(bytes_unpack, &msg_unpack_out);
+    assert(msg_pack_out.SerializeAsString() == msg_pack.SerializeAsString());
+    assert(msg_unpack_out.SerializeAsString() == msg_unpack.SerializeAsString());    
+    std::cout << "all tests passed" << std::endl;
+}

--- a/src/test/dccl_packed_enum/test.proto
+++ b/src/test/dccl_packed_enum/test.proto
@@ -1,0 +1,36 @@
+@PROTOBUF_SYNTAX_VERSION@
+import "dccl/option_extensions.proto";
+
+package dccl.test;
+
+enum Enum
+{
+  ENUM2_A = -2; // for completeness, though negative values are discouraged
+  ENUM2_B = 0;
+  ENUM2_C = 1;
+  ENUM2_D = 2;
+  ENUM2_E = 10;
+  ENUM2_F = 11;
+  ENUM2_G = 12;
+  ENUM2_H = 16777213; // Many skipped values - packed will be 3b, unpacked 24b
+}
+
+message TestMsgPack
+{
+  option (dccl.msg).id = 2;
+  option (dccl.msg).max_bytes = 2;
+  option (dccl.msg).codec_version = 3;
+
+  required int32 five_bit_padding = 1 [(dccl.field) = {min: 0, max: 31}]; // 5b padding.
+  required Enum value = 2 [(dccl.field).packed_enum=true];
+}
+
+message TestMsgUnpack
+{
+  option (dccl.msg).id = 3;
+  option (dccl.msg).max_bytes = 4;
+  option (dccl.msg).codec_version = 3;
+
+  required Enum value = 1 [(dccl.field).packed_enum=false];
+}
+


### PR DESCRIPTION
When set to false, packed_enum will leave gaps in the encoded value range (rather than looking only
at the enum value index).  This fixes #45.