### PR TITLE
Fixed bug when optional message was set but no children were set

### DIFF
--- a/src/codecs3/field_codec_default_message.cpp
+++ b/src/codecs3/field_codec_default_message.cpp
@@ -72,7 +72,7 @@ void dccl::v3::DefaultMessageCodec::any_decode(Bitset* bits, boost::any* wire_va
     {
         
         google::protobuf::Message* msg = boost::any_cast<google::protobuf::Message* >(*wire_value);
-
+        
         if(is_optional())      
         {
             if(!bits->to_ulong())
@@ -148,8 +148,7 @@ void dccl::v3::DefaultMessageCodec::any_decode(Bitset* bits, boost::any* wire_va
 
         std::vector< const google::protobuf::FieldDescriptor* > set_fields;
         refl->ListFields(*msg, &set_fields);
-        if(set_fields.empty() && this_field()) *wire_value = boost::any();
-        else *wire_value = msg;
+        *wire_value = msg;
     }
     catch(boost::bad_any_cast& e)
     {

--- a/src/test/dccl_message_fix/test.cpp
+++ b/src/test/dccl_message_fix/test.cpp
@@ -28,27 +28,25 @@
 #include "dccl/codec.h"
 #include "dccl/codecs2/field_codec_default.h"
 
-#include "test.pb.h"
 #include "dccl/binary.h"
+#include "test.pb.h"
 
 using namespace dccl::test;
 
 int main(int argc, char* argv[])
 {
-//    dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
+    //    dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
     // check the empty messages
     dccl::Codec codec;
-    
+
     codec.info<TestMsg>(&std::cout);
     codec.load<TestMsg>();
-    
+
     {
         TestMsg msg_in, msg_out;
-        int i = 0;
-
 
         std::cout << "Message in:\n" << msg_in.DebugString() << std::endl;
-     
+
         codec.load(msg_in.GetDescriptor());
 
         std::cout << "Try encode..." << std::endl;
@@ -57,18 +55,17 @@ int main(int argc, char* argv[])
         std::cout << "... got bytes (hex): " << dccl::hex_encode(bytes) << std::endl;
 
         std::cout << "Try decode..." << std::endl;
-    
+
         codec.decode(bytes, &msg_out);
-    
+
         std::cout << "... got Message out:\n" << msg_out.DebugString() << std::endl;
 
         assert(!msg_out.has_msg1());
-        assert(!msg_out.msg1_repeat_size());    
+        assert(!msg_out.msg1_repeat_size());
         assert(!msg_out.has_msg2());
-        assert(!msg_out.msg2_repeat_size());    
+        assert(!msg_out.msg2_repeat_size());
         assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
     }
-
 
     // check partially full messages
     {
@@ -82,7 +79,7 @@ int main(int argc, char* argv[])
         msg_in.add_msg2_repeat()->set_val(0.21);
         msg_in.add_msg2_repeat()->set_val(0.22);
         msg_in.add_msg2_repeat()->set_val(0.23);
-        
+
         std::cout << "Message in:\n" << msg_in.DebugString() << std::endl;
 
         std::cout << "Try encode..." << std::endl;
@@ -91,19 +88,41 @@ int main(int argc, char* argv[])
         std::cout << "... got bytes (hex): " << dccl::hex_encode(bytes) << std::endl;
 
         std::cout << "Try decode..." << std::endl;
-    
+
         codec.decode(bytes, &msg_out);
-    
+
         std::cout << "... got Message out:\n" << msg_out.DebugString() << std::endl;
 
         assert(msg_out.has_msg1());
-        assert(msg_out.msg1_repeat_size() == 3);    
+        assert(msg_out.msg1_repeat_size() == 3);
         assert(msg_out.has_msg2());
-        assert(msg_out.msg2_repeat_size() == 3);    
+        assert(msg_out.msg2_repeat_size() == 3);
         assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
     }
-    
-    
+
+    // check message with set submessage but not children
+    {
+        TestMsg msg_in, msg_out;
+
+        msg_in.mutable_msg1();
+        msg_in.mutable_msg2()->set_val(1);
+        std::cout << "Message in:\n" << msg_in.DebugString() << std::endl;
+
+        std::cout << "Try encode..." << std::endl;
+        std::string bytes;
+        codec.encode(&bytes, msg_in);
+        std::cout << "... got bytes (hex): " << dccl::hex_encode(bytes) << std::endl;
+
+        std::cout << "Try decode..." << std::endl;
+
+        codec.decode(bytes, &msg_out);
+
+        std::cout << "... got Message out:\n" << msg_out.DebugString() << std::endl;
+
+        assert(msg_out.has_msg1());
+        assert(msg_out.has_msg2());
+        assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
+    }
+
     std::cout << "all tests passed" << std::endl;
 }
-

--- a/src/test/dccl_message_fix/test.proto
+++ b/src/test/dccl_message_fix/test.proto
@@ -28,6 +28,6 @@ message TestMsg
   // in DCCL v2, these will always be set upon receipt since it has required children. This test validates the fix in v3
   optional EmbeddedMsgRequired msg2 = 2;
   repeated EmbeddedMsgRequired msg2_repeat = 4 [(dccl.field).max_repeat=5];
-
+    
 }
 


### PR DESCRIPTION
In this case, this submessage would not be set upon decode.