### PR TITLE
remove deprecated protobuf include

### DIFF
--- a/src/native_protobuf/dccl_native_protobuf.h
+++ b/src/native_protobuf/dccl_native_protobuf.h
@@ -26,7 +26,9 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <google/protobuf/wire_format_lite.h>
-#include <google/protobuf/wire_format_lite_inl.h>
+#if PROTOBUF_VERSION < 3008000
+#include <google/protobuf/wire_format_lite_inl.h> // this .h has been removed in protobuf 3.8
+#endif
 
 #include "dccl/field_codec_fixed.h"
 #include "dccl/field_codec_typed.h"


### PR DESCRIPTION
Removed from protobuf 3.8.0

https://github.com/protocolbuffers/protobuf/commit/2f864fdfdf18318ef24b02141733adb356508370#diff-487b5245b6a24164ac42967442b09335