### PR TITLE
presence-bit codec prototype

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,4 +27,4 @@ To accept this CLA, please add your name, email, and date to the list below, and
 Toby Schneider <toby@gobysoft.org> 2016-05-13
 Nathan Knotts <nknotts@gmail.com> 2016-05-19
 Chris Murphy <chrismurf@gmail.com> 2018-07-05
-
+Kyle Guilbert <kguilbert@gmail.com> 2019-07-30

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -42,6 +42,7 @@
 #include "dccl/codecs2/field_codec_default.h"
 #include "dccl/codecs3/field_codec_default.h"
 #include "dccl/codecs3/field_codec_var_bytes.h"
+#include "dccl/codecs3/field_codec_presence.h"
 #include "dccl/field_codec_id.h"
 
 #include "dccl/option_extensions.pb.h"
@@ -133,6 +134,15 @@ void dccl::Codec::set_default_codecs()
         FieldCodecManager::add<v3::DefaultBytesCodec, FieldDescriptor::TYPE_BYTES>(default_codec_name(3));
         FieldCodecManager::add<v3::DefaultEnumCodec >(default_codec_name(3));
         FieldCodecManager::add<v3::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(default_codec_name(3));
+
+        // presence bit codec, which encode empty optional fields with a single bit
+        FieldCodecManager::add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<double> > >("dccl.presence");
+        FieldCodecManager::add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<float> > >("dccl.presence");
+        FieldCodecManager::add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<int32> > >("dccl.presence");
+        FieldCodecManager::add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<int64> > >("dccl.presence");
+        FieldCodecManager::add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<uint32> > >("dccl.presence");
+        FieldCodecManager::add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<uint64> > >("dccl.presence");
+        FieldCodecManager::add<v3::PresenceBitCodec<v3::DefaultEnumCodec > >("dccl.presence");
 
         // alternative bytes codec that more efficiently encodes variable length bytes fields
         FieldCodecManager::add<v3::VarBytesCodec, FieldDescriptor::TYPE_BYTES>("dccl.var_bytes");

--- a/src/codecs2/field_codec_default.h
+++ b/src/codecs2/field_codec_default.h
@@ -53,7 +53,7 @@ namespace dccl
         template<typename WireType, typename FieldType = WireType>
             class DefaultNumericFieldCodec : public TypedFixedFieldCodec<WireType, FieldType>
             {
-              protected:
+            public:
 
               virtual double max()
               { return FieldCodecBase::dccl_field_options().max(); }
@@ -162,6 +162,9 @@ namespace dccl
 
                   return wire_value;
               }
+
+              // bring size(const WireType&) into scope so callers can access it
+              using TypedFixedFieldCodec<WireType, FieldType>::size;
 
               unsigned size()
               {

--- a/src/codecs3/field_codec_default.h
+++ b/src/codecs3/field_codec_default.h
@@ -51,10 +51,10 @@ namespace dccl
           public:
             int32 pre_encode(const google::protobuf::EnumValueDescriptor* const& field_value);
             const google::protobuf::EnumValueDescriptor* post_decode(const int32& wire_value);
+            void validate() { }
 
           private:
-            void validate() { }
-            
+
             double max();
             double min();
         };
@@ -77,7 +77,7 @@ namespace dccl
         /// [length of following string size: ceil(log2(max_length))][string]
         class DefaultStringCodec : public TypedFieldCodec<std::string>
         {
-          private:
+        private:
             Bitset encode();
             Bitset encode(const std::string& wire_value);
             std::string decode(Bitset* bits);

--- a/src/codecs3/field_codec_presence.h
+++ b/src/codecs3/field_codec_presence.h
@@ -1,0 +1,167 @@
+// Copyright 2009-2017 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef FIELD_CODEC_PRESENCE_20190722H
+#define FIELD_CODEC_PRESENCE_20190722H
+
+#include "dccl/field_codec_typed.h"
+
+namespace dccl
+{
+    namespace v3
+    {
+
+        /// \brief Encodes empty optional fields with a single "presence" bit.
+        ///
+        /// This class wraps an existing TypedFieldCodec, adding an extra "presence" bit to the LSB for optional fields.
+        /// The field size is as follows:
+        /// - Optional
+        ///     - Empty: 1 bit
+        ///     - Non-empty: size of WrappedType + 1
+        /// - Required
+        ///     - Empty: size of WrappedType
+        ///     - Non-empty: size of WrappedType
+        template<typename WrappedType>
+        class PresenceBitCodec: public TypedFieldCodec<typename WrappedType::wire_type, typename WrappedType::field_type>
+        {
+
+        public:
+
+            using Base = TypedFieldCodec<typename WrappedType::wire_type, typename WrappedType::field_type>;
+
+            /// The codec type of the "wrapped" codec
+            using wrapped_type = WrappedType;
+
+            /// The wire_type of the "wrapped" codec
+            using wire_type = typename Base::wire_type;
+
+            /// The field_type of the "wrapped" codec
+            using field_type = typename Base::field_type;
+
+        protected:
+
+            /// Instance of the "wrapped" codec
+            WrappedType _inner_codec;
+
+        public:
+            // required when wire_type != field_type
+            virtual wire_type pre_encode(const field_type& field_value)
+            {
+                return _inner_codec.pre_encode(field_value);
+            }
+
+            // required when wire_type != field_type
+            virtual field_type post_decode(const wire_type& wire_value)
+            {
+                return _inner_codec.post_decode(wire_value);
+            }
+
+            /// Calls _inner_codec.validate()
+            virtual void validate() override
+            {
+                _inner_codec.validate();
+            }
+
+            /// Encodes an empty field as a single 0 bit
+            virtual Bitset encode()
+            {
+                return Bitset(1, 0); // presence bit == false
+            }
+
+            /// Encodes a non-empty field, adding a 1 bit to the front for optional fields
+            virtual Bitset encode(const wire_type& value)
+            {
+                Bitset encoded = _inner_codec.encode(value);
+
+                if (!this->use_required()) {
+                    encoded.push_front(true);
+                }
+                return encoded;
+            }
+
+            /// Decodes a field, first evaluating the presence bit if necessary
+            virtual wire_type decode(Bitset* bits) override
+            {
+                if (!this->use_required())
+                {
+                    // optional field: bits contains only the presence bit
+                    bool present = bits->front();
+                    if (!present)
+                    {
+                        throw NullValueException();
+                    }
+                    // the single bit was the presence bit; consume it and get the rest
+                    bits->pop_front();
+                    bits->get_more_bits(_inner_codec.size());
+                }
+
+                return _inner_codec.decode(bits);
+            }
+
+            /// Size of an empty field (1 bit)
+            virtual unsigned size() override
+            {
+                // empty field is always 1 bit (only occurs for optional fields)
+                return 1;
+            }
+
+            /// Size of a non-empty field; gets size from "wrapped" codec, adds 1 for optional fields
+            virtual unsigned size(const wire_type& wire_value) override
+            {
+                int presence_bits = this->use_required() ? 0 : 1;
+                return presence_bits + _inner_codec.size(wire_value);
+            }
+
+            virtual unsigned max_size() override
+            {
+                if (this->use_required())
+                {
+                    // def to "wrapped" codec
+                    return _inner_codec.max_size();
+                } else
+                {
+                    // optional fields have the extra presence bit
+                    return _inner_codec.max_size() + 1;
+                }
+            }
+
+            virtual unsigned min_size() override
+            {
+                if (this->use_required())
+                {
+                    // defer to "wrapped" codec
+                    return _inner_codec.min_size();
+                } else
+                {
+                    // optional fields encode as 1 bit minimum
+                    return 1;
+                }
+            }
+
+        };
+    }
+}
+
+
+
+#endif /* FIELD_CODEC_PRESENCE_20190722H */

--- a/src/codecs3/field_codec_presence.h
+++ b/src/codecs3/field_codec_presence.h
@@ -64,6 +64,10 @@ namespace dccl
             WrappedType _inner_codec;
 
         public:
+            PresenceBitCodec() {
+                _inner_codec.set_force_use_required(true);
+            }
+
             // required when wire_type != field_type
             virtual wire_type pre_encode(const field_type& field_value)
             {

--- a/src/codecs3/field_codec_presence.h
+++ b/src/codecs3/field_codec_presence.h
@@ -47,16 +47,16 @@ namespace dccl
 
         public:
 
-            using Base = TypedFieldCodec<typename WrappedType::wire_type, typename WrappedType::field_type>;
+            typedef TypedFieldCodec<typename WrappedType::wire_type, typename WrappedType::field_type> Base;
 
             /// The codec type of the "wrapped" codec
-            using wrapped_type = WrappedType;
+            typedef WrappedType wrapped_type;
 
             /// The wire_type of the "wrapped" codec
-            using wire_type = typename Base::wire_type;
+            typedef typename Base::wire_type wire_type;
 
             /// The field_type of the "wrapped" codec
-            using field_type = typename Base::field_type;
+            typedef typename Base::field_type field_type;
 
         protected:
 
@@ -77,7 +77,7 @@ namespace dccl
             }
 
             /// Calls _inner_codec.validate()
-            virtual void validate() override
+            virtual void validate()
             {
                 _inner_codec.validate();
             }
@@ -100,7 +100,7 @@ namespace dccl
             }
 
             /// Decodes a field, first evaluating the presence bit if necessary
-            virtual wire_type decode(Bitset* bits) override
+            virtual wire_type decode(Bitset* bits)
             {
                 if (!this->use_required())
                 {
@@ -119,20 +119,20 @@ namespace dccl
             }
 
             /// Size of an empty field (1 bit)
-            virtual unsigned size() override
+            virtual unsigned size()
             {
                 // empty field is always 1 bit (only occurs for optional fields)
                 return 1;
             }
 
             /// Size of a non-empty field; gets size from "wrapped" codec, adds 1 for optional fields
-            virtual unsigned size(const wire_type& wire_value) override
+            virtual unsigned size(const wire_type& wire_value)
             {
                 int presence_bits = this->use_required() ? 0 : 1;
                 return presence_bits + _inner_codec.size(wire_value);
             }
 
-            virtual unsigned max_size() override
+            virtual unsigned max_size()
             {
                 if (this->use_required())
                 {
@@ -145,7 +145,7 @@ namespace dccl
                 }
             }
 
-            virtual unsigned min_size() override
+            virtual unsigned min_size()
             {
                 if (this->use_required())
                 {

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -39,7 +39,7 @@ using namespace dccl::logger;
 //
 // FieldCodecBase public
 //
-dccl::FieldCodecBase::FieldCodecBase() { }
+dccl::FieldCodecBase::FieldCodecBase() : force_required_(false) { }
             
 void dccl::FieldCodecBase::base_encode(Bitset* bits,
                                        const google::protobuf::Message& field_value,

--- a/src/field_codec.h
+++ b/src/field_codec.h
@@ -119,6 +119,11 @@ namespace dccl
 
         static bool strict() { return strict_; }
         
+        /// \brief Force the codec to always use the "required" field encoding, regardless of the FieldDescriptor setting. Useful when wrapping this codec in another that handles optional and repeated fields
+        void set_force_use_required(bool force_required = true)
+        {
+            bool force_required_ = force_required;
+        }
         
         //@}
 
@@ -347,6 +352,9 @@ namespace dccl
         /// \brief Whether to use the required or optional encoding
         bool use_required()
         {
+            if(force_required_)
+                return true;
+
             const google::protobuf::FieldDescriptor* field = this_field();
             if(!field)
                 return true;
@@ -494,6 +502,8 @@ namespace dccl
         std::string name_;
         google::protobuf::FieldDescriptor::Type field_type_;
         google::protobuf::FieldDescriptor::CppType wire_type_;
+
+        bool force_required_;
 
     };
 

--- a/src/field_codec.h
+++ b/src/field_codec.h
@@ -122,7 +122,7 @@ namespace dccl
         /// \brief Force the codec to always use the "required" field encoding, regardless of the FieldDescriptor setting. Useful when wrapping this codec in another that handles optional and repeated fields
         void set_force_use_required(bool force_required = true)
         {
-            bool force_required_ = force_required;
+            force_required_ = force_required;
         }
         
         //@}

--- a/src/field_codec_fixed.h
+++ b/src/field_codec_fixed.h
@@ -33,11 +33,11 @@ namespace dccl
     template<typename WireType, typename FieldType = WireType>
         class TypedFixedFieldCodec : public TypedFieldCodec<WireType, FieldType>
     {
-      protected:
+      public:
       /// \brief The size of the encoded message in bits. Use TypedFieldCodec if the size depends on the data.
       virtual unsigned size() = 0;
           
-      private:
+      public:
       unsigned size(const WireType& wire_value)
       { return size(); }
           

--- a/src/field_codec_typed.h
+++ b/src/field_codec_typed.h
@@ -41,7 +41,7 @@ namespace dccl
     template <typename WireType, typename FieldType, class Enable = void> 
         class FieldCodecSelector : public FieldCodecBase
         {
-          protected:
+        public:
 /// \brief Convert from the FieldType representation (used in the Google Protobuf message) to the WireType representation (used with encode() and decode(), i.e. "on the wire").
           /// 
           /// \param field_value Value to convert
@@ -62,7 +62,7 @@ namespace dccl
         typename boost::enable_if<boost::is_same<WireType, FieldType> >::type>
         : public FieldCodecBase
     {
-      protected:
+      public:
         /// \brief No-op version of pre_encode (since FieldType == WireType)
         virtual WireType pre_encode(const FieldType& field_value)
         { return field_value; }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(dccl_message_fix)
 add_subdirectory(dccl_strict)
 add_subdirectory(dccl_packed_enum)
 add_subdirectory(dccl_dynamic_protobuf)
+add_subdirectory(dccl_presence)
 
 if(enable_units)
   add_subdirectory(dccl_units)

--- a/src/test/dccl_presence/CMakeLists.txt
+++ b/src/test/dccl_presence/CMakeLists.txt
@@ -1,0 +1,6 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test.proto)
+
+add_executable(dccl_test_presence test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(dccl_test_presence dccl)
+
+add_test(dccl_test_presence ${dccl_BIN_DIR}/dccl_test_presence)

--- a/src/test/dccl_presence/test.cpp
+++ b/src/test/dccl_presence/test.cpp
@@ -116,7 +116,7 @@ void test2(dccl::Codec& codec)
     std::string encoded;
     codec.encode(&encoded, msg_in);
 
-    assert(encoded.size() == 34);
+    assert(encoded.size() == 33);
 
     PresenceMsg msg_out;
     codec.decode(encoded, &msg_out);

--- a/src/test/dccl_presence/test.cpp
+++ b/src/test/dccl_presence/test.cpp
@@ -1,0 +1,155 @@
+// Copyright 2009-2017 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
+// tests required versus optional encoding of fields using a presence bit
+
+#include "dccl/codec.h"
+#include "test/dccl_presence/test.pb.h"
+using namespace dccl::test;
+
+using dccl::operator<<;
+
+void test1(dccl::Codec&);
+void test2(dccl::Codec&);
+
+int main(int argc, char* argv[])
+{
+    dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
+    
+    dccl::Codec codec;
+    codec.load<PresenceMsg>();
+    codec.info<PresenceMsg>(&dccl::dlog);
+    test1(codec);
+    test2(codec);
+
+    std::cout << "all tests passed" << std::endl;
+}
+
+// optional fields all left empty
+void test1(dccl::Codec& codec)
+{
+    PresenceMsg msg_in;
+
+    msg_in.set_req_i32(-100);
+    msg_in.set_req_i64(65535);
+    msg_in.set_req_ui32(1022);
+    msg_in.set_req_ui64(101);
+    msg_in.set_req_float(900.12345);
+    msg_in.set_req_double(900.12345678);
+    msg_in.set_req_enum(ENUM2_C);
+
+    std::string encoded;
+    codec.encode(&encoded, msg_in);
+
+    assert(encoded.size() == 17);
+    
+    PresenceMsg msg_out;
+    codec.decode(encoded, &msg_out);
+
+    assert(msg_in.req_i32() == msg_out.req_i32());
+    assert(msg_in.req_i64() == msg_out.req_i64());
+    assert(msg_in.req_ui32() == msg_out.req_ui32());
+    assert(msg_in.req_ui64() == msg_out.req_ui64());
+    assert(fabsf(msg_in.req_float() - msg_out.req_float()) < 1e-4);
+    assert(fabs(msg_in.req_double() - msg_out.req_double()) < 1e-7);
+    assert(msg_in.req_enum() == msg_out.req_enum());
+
+    assert(!msg_out.has_opt_i32());
+    assert(!msg_out.has_opt_i64());
+    assert(!msg_out.has_opt_ui32());
+    assert(!msg_out.has_opt_ui64());
+    assert(!msg_out.has_opt_float());
+    assert(!msg_out.has_opt_double());
+    assert(!msg_out.has_opt_enum());
+
+    assert(msg_out.repeat_i32_size() == 0);
+    assert(msg_out.repeat_enum_size() == 0);
+
+    std::cout << "test1 passed" << std::endl;
+}
+
+// all fields populated
+void test2(dccl::Codec& codec)
+{
+    PresenceMsg msg_in;
+
+    msg_in.set_req_i32(500);
+    msg_in.set_req_i64(0);
+    msg_in.set_req_ui32(0);
+    msg_in.set_req_ui64(100);
+    msg_in.set_req_float(-900.12345);
+    msg_in.set_req_double(-900.12345678);
+    msg_in.set_req_enum(ENUM2_A);
+
+    msg_in.set_opt_i32(-100);
+    msg_in.set_opt_i64(65535);
+    msg_in.set_opt_ui32(0);
+    msg_in.set_opt_ui64(1123);
+    msg_in.set_opt_float(-900.12345);
+    msg_in.set_opt_double(900.12345678);
+    msg_in.set_opt_enum(ENUM2_A);
+
+    msg_in.add_repeat_i32(500);
+    msg_in.add_repeat_enum(ENUM2_A);
+    msg_in.add_repeat_enum(ENUM2_B);
+    msg_in.add_repeat_enum(ENUM2_C);
+
+
+    std::string encoded;
+    codec.encode(&encoded, msg_in);
+
+    assert(encoded.size() == 34);
+
+    PresenceMsg msg_out;
+    codec.decode(encoded, &msg_out);
+
+    assert(msg_in.req_i32() == msg_out.req_i32());
+    assert(msg_in.req_i64() == msg_out.req_i64());
+    assert(msg_in.req_ui32() == msg_out.req_ui32());
+    assert(msg_in.req_ui64() == msg_out.req_ui64());
+    assert(fabsf(msg_in.req_float() - msg_out.req_float()) < 1e-4);
+    assert(fabs(msg_in.req_double() - msg_out.req_double()) < 1e-7);
+    assert(msg_in.req_enum() == msg_out.req_enum());
+
+    assert(msg_out.has_opt_i32());
+    assert(msg_out.has_opt_i64());
+    assert(msg_out.has_opt_ui32());
+    assert(msg_out.has_opt_ui64());
+    assert(msg_out.has_opt_float());
+    assert(msg_out.has_opt_double());
+    assert(msg_out.has_opt_enum());
+
+    assert(msg_in.opt_i32() == msg_out.opt_i32());
+    assert(msg_in.opt_i64() == msg_out.opt_i64());
+    assert(msg_in.opt_ui32() == msg_out.opt_ui32());
+    assert(msg_in.opt_ui64() == msg_out.opt_ui64());
+    assert(fabsf(msg_in.opt_float() - msg_out.opt_float()) < 1e-4);
+    assert(fabs(msg_in.opt_double() - msg_out.opt_double()) < 1e-7);
+    assert(msg_in.opt_enum() == msg_out.opt_enum());
+
+    assert(msg_in.repeat_i32_size() == msg_out.repeat_i32_size());
+    assert(std::equal(msg_in.repeat_i32().begin(), msg_in.repeat_i32().end(), msg_out.repeat_i32().begin()));
+    assert(msg_in.repeat_enum_size() == msg_out.repeat_enum_size());
+    assert(std::equal(msg_in.repeat_enum().begin(), msg_in.repeat_enum().end(), msg_out.repeat_enum().begin()));
+
+
+    std::cout << "test2 passed" << std::endl;
+}

--- a/src/test/dccl_presence/test.proto
+++ b/src/test/dccl_presence/test.proto
@@ -1,0 +1,41 @@
+@PROTOBUF_SYNTAX_VERSION@
+import "dccl/option_extensions.proto";
+package dccl.test;
+
+enum Enum
+{
+  ENUM2_A = 3;
+  ENUM2_B = 4;
+  ENUM2_C = 5;
+
+}
+
+message PresenceMsg
+{
+    option (dccl.msg).id = 10;
+    option (dccl.msg).max_bytes = 54;
+    option (dccl.msg).codec_version = 3;
+
+    // optional fields gain an extra bit set to 1
+    required int32 req_i32 = 1 [(dccl.field) = { codec: "dccl.presence", min: -100, max: 500 } ];
+    required int64 req_i64 = 2 [(dccl.field) = { codec: "dccl.presence", min: 0, max: 65535 } ];
+    required uint32 req_ui32 = 3 [(dccl.field) = { codec: "dccl.presence", min: 0, max: 1022 } ];
+    required uint64 req_ui64 = 4 [(dccl.field) = { codec: "dccl.presence", min: 100, max: 1123 } ];
+    required float req_float = 5 [(dccl.field) = { codec: "dccl.presence", min: -1000, max: 1000, precision: 5 } ];
+    required double req_double = 6 [(dccl.field) = { codec: "dccl.presence", min: -1000, max: 1000, precision: 8 } ];
+    required Enum req_enum = 7 [(dccl.field) = { codec: "dccl.presence" } ];
+    
+    // optional fields will gain an extra bit; when unpopulated, the fields are encoded with this bit only
+    optional int32 opt_i32 = 8 [(dccl.field) = { codec: "dccl.presence", min: -100, max: 500 } ];
+    optional int64 opt_i64 = 9 [(dccl.field) = { codec: "dccl.presence", min: 0, max: 65535 } ];
+    optional uint32 opt_ui32 = 10 [(dccl.field) = { codec: "dccl.presence", min: 0, max: 1022 } ];
+    optional uint64 opt_ui64 = 11 [(dccl.field) = { codec: "dccl.presence", min: 100, max: 1123 } ];
+    optional float opt_float = 12 [(dccl.field) = { codec: "dccl.presence", min: -1000, max: 1000, precision: 5 } ];
+    optional double opt_double = 13 [(dccl.field) = { codec: "dccl.presence", min: -1000, max: 1000, precision: 8 } ];
+    optional Enum opt_enum = 14 [(dccl.field) = { codec: "dccl.presence" } ];
+
+    // note: since repeated fields are treated like "required" fields, they are unaffected by the presence codec    
+    repeated int32 repeat_i32 = 15 [(dccl.field) = { codec: "dccl.presence", min: -100, max: 500, max_repeat: 2 }];
+    repeated Enum repeat_enum = 16 [(dccl.field) = { codec: "dccl.presence", max_repeat: 3 } ];
+}
+


### PR DESCRIPTION
@tsaubergine: @chrismurf and myself have created a new "presence bit codec" which instantiates an existing codec and encodes optional empty fields using a single bit. It's particularly intended for numeric types but could also be used for strings. Looking for your recommendation on the best way to contribute this feature upstream. Here are the two primary  questions/concerns as I see them:

1. I decided to create an instance of the "wrapped" codec in PresenceBitCodec to re-use existing codecs. In order to defer to those codecs' methods, e.g. size(), encode(), decode(), I had to change a few private or protected methods to public. This transformation is incomplete, and so the new codec can't yet be used for codecs having those methods private or protected.
2. Because PresenceBitCodec simply defers to the "wrapped" codec, which is usually DefaultNumericFieldCodec, it inherits the "presence value" used by DefaultNumericFieldCodec, which sometimes results in wasting an extra bit if log2(max-min) is exactly a power of 2. We've been thinking of ways to get around this, none of which are particularly attractive (for example, recreating the code in DefaultNumericFieldCodec or even pushing a fake field descriptor on the stack to trick the size() method). 
