### PR TITLE
4.0.0 - Minor functionality and QoL improvements to Python bindings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Chris Murphy <chrismurf@gmail.com> 2018-07-05
 Kyle Guilbert <kguilbert@gmail.com> 2019-07-30
 Russ Webber <russ@rw.id.au> 2019-10-02
 Davide Fenucci <davfen@noc.ac.uk> 2021-07-13
+Phil Skelton <philboske@gmail.com> 2022-07-12

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -19,7 +19,8 @@ os.environ["CC"]='@CMAKE_C_COMPILER@'
 os.environ["CXX"]='@CMAKE_CXX_COMPILER@'
 
 def get_version():
-    return open('@CMAKE_SOURCE_DIR@/version.txt', 'r').readline().strip()
+  # Resolves a PEP 440 warning for invalid versions when, e.g., version is 4.0.0~alpha0.
+  return open('@CMAKE_SOURCE_DIR@/version.txt', 'r').readline().strip().split('~')[0]
 
 class clean(_clean):
   def run(self):


### PR DESCRIPTION
Added simple version parsing improvement to Python setup, as previously done for C++ in d0108edb79cb7b0507c0cf3d3beed237789c0169 as part of #75. It's only a warning, but it was annoying.

Exposed dccl::Codec::set_strict() in Python bindings, including dccl::OutOfRangeException error pass-through and handling in encode().