### PR TITLE
4.0.0 - Improvements to dccl::Codec console formatting.

### DIFF
--- a/src/apps/dccl/dccl_tool.cpp
+++ b/src/apps/dccl/dccl_tool.cpp
@@ -537,7 +537,15 @@ void parse_options(int argc, char* argv[], dccl::tool::Config* cfg, int &console
                 }
                 else if ((errno == 0) && optarg && !*end_ptr)
                 {
-                    console_width_ = number;
+                    if (number >= 0)
+                    {
+                        console_width_ = number;
+                    }
+                    else
+                    {
+                        std::cerr << "Option -w value \'" << optarg << "\' was invalid (negative number)." << std::endl;
+                        exit(EXIT_FAILURE);
+                    }
                 }
                 else
                 {

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -60,15 +60,13 @@ using google::protobuf::FieldDescriptor;
 using google::protobuf::Descriptor;
 using google::protobuf::Reflection;
 
-const unsigned full_width = 60;
-
 
 //
 // Codec
 //
 
 dccl::Codec::Codec(const std::string& dccl_id_codec, const std::string& library_path)
-    : strict_(false), id_codec_(dccl_id_codec)
+    : strict_(false), id_codec_(dccl_id_codec), console_width_(60)
 {
     set_default_codecs();
     FieldCodecManager::add<DefaultIdentifierCodec>(default_id_codec_name());
@@ -531,8 +529,7 @@ void dccl::Codec::info(const google::protobuf::Descriptor* desc, std::ostream* p
             const unsigned allowed_bit_size = allowed_byte_size * BITS_IN_BYTE;
 
             std::string message_name = boost::lexical_cast<std::string>(dccl_id) + ": " + desc->full_name();
-            std::string guard = std::string((full_width-message_name.size())/2, '=');
-
+            std::string guard = build_guard_for_console_output(message_name, '=');
             std::string bits_dccl_head_str = "dccl.id head";
             std::string bits_user_head_str = "user head";
             std::string bits_body_str = "body";
@@ -553,14 +550,16 @@ void dccl::Codec::info(const google::protobuf::Descriptor* desc, std::ostream* p
                 << allowed_bit_size << " bits\n";
 
             std::string header_str = "Header";
-            std::string header_guard = std::string((full_width-header_str.size())/2, '-');
+            std::string header_guard = build_guard_for_console_output(header_str, '-');
+
             *os << header_guard << " " << header_str << " " << header_guard << std::endl;
             *os << bits_dccl_head_str << std::setfill('.') << std::setw(bits_width-bits_dccl_head_str.size()+spaces) << id_bit_size << " {" << id_codec()->name() <<  "}\n";
             codec->base_info(os, desc, HEAD);
 //            *os << std::string(header_str.size() + 2 + 2*header_guard.size(), '-') << std::endl;
 
             std::string body_str = "Body";
-            std::string body_guard = std::string((full_width-body_str.size())/2, '-');
+            std::string body_guard = build_guard_for_console_output(body_str, '-');
+
             *os << body_guard << " " << body_str << " " << body_guard << std::endl;
             codec->base_info(os, desc, BODY);
 //            *os << std::string(body_str.size() + 2 + 2*body_guard.size(), '-') << std::endl;
@@ -680,9 +679,9 @@ void dccl::Codec::info_all(std::ostream* param_os /*= 0 */) const
     if(param_os || dlog.is(INFO))
     {
         std::string codec_str = "Dynamic Compact Control Language (DCCL) Codec";
-        std::string codec_guard = std::string((full_width-codec_str.size())/2, '|');
-        *os << codec_guard << " " << codec_str << " " << codec_guard << std::endl;
+        std::string codec_guard = build_guard_for_console_output(codec_str, '|');
 
+        *os << codec_guard << " " << codec_str << " " << codec_guard << std::endl;
         *os << id2desc_.size() << " messages loaded.\n";
         *os << "Field sizes are in bits unless otherwise noted." << std::endl;
 
@@ -702,4 +701,11 @@ void dccl::Codec::set_id_codec(const std::string& id_codec_name)
     id_codec_ = id_codec_name;
     // make sure the id codec exists
     id_codec();
+}
+
+
+std::string dccl::Codec::build_guard_for_console_output(std::string& base, char guard_char) const
+{
+    // Only guard if possible, otherwise return an empty string rather than throwing a std::length_error.
+    return (base.size() < console_width_) ? std::string((console_width_-base.size())/2, guard_char) : std::string();
 }

--- a/src/codec.h
+++ b/src/codec.h
@@ -146,6 +146,12 @@ namespace dccl
         /// \param mode "true" sets strict mode, "false" disables strict mode
         void set_strict(bool mode) { strict_ = mode; }
         
+
+        /// \brief Set the number of characters used in programmatic generation of console outputs.
+        ///
+        /// \param num_chars Character limit for line widths on console outputs
+        void set_console_width(unsigned num_chars) { console_width_ = num_chars; }
+
         //@}
             
         /// \name Informational Methods.
@@ -365,6 +371,7 @@ namespace dccl
             return FieldCodecManager::find(google::protobuf::FieldDescriptor::TYPE_UINT32,
                                            id_codec_);
         }
+
         
       private:
         // SHA256 hash of the crypto passphrase
@@ -372,6 +379,9 @@ namespace dccl
 
         // strict mode setting
         bool strict_;
+
+        // console outputting format width
+        unsigned console_width_;
         
 	// set of DCCL IDs *not* to encrypt        
 	std::set<unsigned> skip_crypto_ids_;
@@ -381,7 +391,8 @@ namespace dccl
         std::string id_codec_;
 
         std::vector<void *> dl_handles_;
-        
+
+        std::string build_guard_for_console_output(std::string& base, char guard_char) const;
     };
 
     inline std::ostream& operator<<(std::ostream& os, const Codec& codec)

--- a/src/protobuf/option_extensions.proto
+++ b/src/protobuf/option_extensions.proto
@@ -6,5 +6,6 @@
   which dccl/protobuf/... did not.
   --------------------------------------------------------------------*/
 
+syntax = "proto2";
 import public "dccl/option_extensions.proto";
 package dccl;


### PR DESCRIPTION
Addresses discussions in https://github.com/GobySoft/dccl/issues/83, plus a compilation warning that was annoying.