### PR TITLE
4.0 use v4 message codec for native protobuf

### DIFF
--- a/src/codecs4/field_codec_default_message.h
+++ b/src/codecs4/field_codec_default_message.h
@@ -202,11 +202,6 @@ class DefaultMessageCodec : public FieldCodecBase
                           const google::protobuf::FieldDescriptor* field_desc)
         {
             codec->field_validate(return_value, field_desc);
-
-            // If the field belongs to a oneof, check also that no codec has been specified
-            if (is_part_of_oneof(field_desc))
-                codec->require(!field_desc->options().GetExtension(dccl::field).has_codec(),
-                               "fields belonging to a oneof cannot specify a codec.");
         }
 
         static void oneof(bool*, const google::protobuf::OneofDescriptor*)

--- a/src/native_protobuf/dccl_native_protobuf.cpp
+++ b/src/native_protobuf/dccl_native_protobuf.cpp
@@ -22,6 +22,7 @@
 
 #include "dccl_native_protobuf.h"
 #include "dccl/codec.h"
+#include "dccl/codecs4/field_codec_default_message.h"
 
 extern "C"
 {
@@ -33,7 +34,7 @@ extern "C"
 
         const char* native_pb_group = "dccl.native_protobuf";
         
-        FieldCodecManager::add<v3::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(native_pb_group);
+        FieldCodecManager::add<v4::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(native_pb_group);
         FieldCodecManager::add<PrimitiveTypeFieldCodec<dccl::int64, FieldDescriptor::TYPE_INT64>,
                                FieldDescriptor::TYPE_INT64>(native_pb_group);
         FieldCodecManager::add<PrimitiveTypeFieldCodec<dccl::int32, FieldDescriptor::TYPE_INT32>,
@@ -116,7 +117,7 @@ extern "C"
         FieldCodecManager::remove<EnumFieldCodec, FieldDescriptor::TYPE_ENUM>(native_pb_group);
 
         
-        FieldCodecManager::remove<v3::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(native_pb_group);
+        FieldCodecManager::remove<v4::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(native_pb_group);
                     
     }
 }

--- a/src/test/dccl_oneof/CMakeLists.txt
+++ b/src/test/dccl_oneof/CMakeLists.txt
@@ -1,6 +1,8 @@
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test.proto)
 
 add_executable(dccl_test_oneof test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(dccl_test_oneof dccl)
+target_compile_definitions(dccl_test_oneof PRIVATE DCCL_NATIVE_PROTOBUF_NAME="$<TARGET_SONAME_FILE_NAME:dccl_native_protobuf>")
+
+target_link_libraries(dccl_test_oneof dccl dccl_native_protobuf)
 
 add_test(dccl_test_oneof ${dccl_BIN_DIR}/dccl_test_oneof)

--- a/src/test/dccl_oneof/test.cpp
+++ b/src/test/dccl_oneof/test.cpp
@@ -36,6 +36,9 @@ int main(int argc, char* argv[])
 {
     dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
 
+    codec.load_library(DCCL_NATIVE_PROTOBUF_NAME);
+
+    
     {
         TestMsg msg_in;
         msg_in.set_double_oneof1(10.56);
@@ -60,6 +63,29 @@ int main(int argc, char* argv[])
         assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
     }
 
+    // test non standard codec
+    {
+        TestMsg msg_in;
+        msg_in.set_non_default_double(1200.56);
+        msg_in.mutable_msg_oneof2()->set_val(100.123);
+
+        std::cout << "Message in:\n" << msg_in.DebugString() << std::endl;
+        std::cout << "Try encode..." << std::endl;
+        std::string bytes;
+        codec.encode(&bytes, msg_in);
+        std::cout << "... got bytes (hex): " << dccl::hex_encode(bytes) << std::endl;
+
+        std::cout << "Try decode..." << std::endl;
+        std::cout << codec.max_size(msg_in.GetDescriptor()) << std::endl;
+
+        TestMsg msg_out;
+        codec.decode(bytes, &msg_out);
+
+        std::cout << "... got Message out:\n" << msg_out.DebugString() << std::endl;
+        assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
+    }
+
+    
     // Test exception thrown for in_head oneof fields
     try {
         InvalidTestMsg msg_in;

--- a/src/test/dccl_oneof/test.cpp
+++ b/src/test/dccl_oneof/test.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 
 #include <google/protobuf/descriptor.pb.h>
+#include "dccl/native_protobuf/dccl_native_protobuf.h"
 
 #include "dccl/codec.h"
 #include "test.pb.h"
@@ -31,6 +32,10 @@
 using namespace dccl::test;
 
 dccl::Codec codec;
+
+// ensure we link in dccl_native_protobuf.so
+dccl::native_protobuf::EnumFieldCodec dummy;
+
 
 int main(int argc, char* argv[])
 {

--- a/src/test/dccl_oneof/test.proto
+++ b/src/test/dccl_oneof/test.proto
@@ -1,18 +1,22 @@
 @PROTOBUF_SYNTAX_VERSION@
+
 import "dccl/option_extensions.proto";
 
 package dccl.test;
 
 message EmbeddedMsg1
 {
-    optional double val = 1 [(dccl.field).min=0,
-                             (dccl.field).max=126,
-                             (dccl.field).precision=3];
-    oneof nested_oneof {
-        int32 int32_nested_oneof = 116 [(dccl.field).min=0,
-                                         (dccl.field).max=31];
-        double double_nested_oneof = 117 [(dccl.field).min=-1,
-                                          (dccl.field).max=126];
+    optional double val = 1 [
+        (dccl.field).min = 0,
+        (dccl.field).max = 126,
+        (dccl.field).precision = 3
+    ];
+    oneof nested_oneof
+    {
+        int32 int32_nested_oneof = 116
+            [(dccl.field).min = 0, (dccl.field).max = 31];
+        double double_nested_oneof = 117
+            [(dccl.field).min = -1, (dccl.field).max = 126];
     }
 }
 
@@ -22,17 +26,23 @@ message TestMsg
     option (dccl.msg).max_bytes = 32;
     option (dccl.msg).codec_version = 4;
 
-    oneof test_oneof1 {
-        double double_oneof1 = 118 [(dccl.field).min=-100,
-                                    (dccl.field).max=126,
-                                    (dccl.field).precision=2];
+    oneof test_oneof1
+    {
+        double double_oneof1 = 118 [
+            (dccl.field).min = -100,
+            (dccl.field).max = 126,
+            (dccl.field).precision = 2
+        ];
 
         EmbeddedMsg1 msg_oneof1 = 119;
+        double non_default_double = 122
+            [(dccl.field).codec = "dccl.native_protobuf"];
     }
 
-    oneof test_oneof2 {
-        int32 int32_oneof2 = 120 [(dccl.field).min=-20,
-                                  (dccl.field).max=3000];
+    oneof test_oneof2
+    {
+        int32 int32_oneof2 = 120
+            [(dccl.field).min = -20, (dccl.field).max = 3000];
         EmbeddedMsg1 msg_oneof2 = 121;
     }
 }
@@ -43,18 +53,22 @@ message InvalidTestMsg
     option (dccl.msg).max_bytes = 32;
     option (dccl.msg).codec_version = 4;
 
-    oneof test_oneof1 {
-        double double_oneof1 = 118 [(dccl.field).min=-100,
-                                    (dccl.field).max=126,
-                                    (dccl.field).in_head=true,
-                                    (dccl.field).precision=2];
+    oneof test_oneof1
+    {
+        double double_oneof1 = 118 [
+            (dccl.field).min = -100,
+            (dccl.field).max = 126,
+            (dccl.field).in_head = true,
+            (dccl.field).precision = 2
+        ];
 
         EmbeddedMsg1 msg_oneof1 = 119;
     }
 
-    oneof test_oneof2 {
-        int32 int32_oneof2 = 120 [(dccl.field).min=-20,
-                                  (dccl.field).max=3000];
+    oneof test_oneof2
+    {
+        int32 int32_oneof2 = 120
+            [(dccl.field).min = -20, (dccl.field).max = 3000];
         EmbeddedMsg1 msg_oneof2 = 121;
     }
 }


### PR DESCRIPTION
Also allow use of non default codec for oneof fields (not sure why this was originally prohibited).