### PR TITLE
4.0: Optional verbose error outputs on encode for required fields.

### DIFF
--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -65,7 +65,7 @@ using google::protobuf::Reflection;
 //
 
 dccl::Codec::Codec(const std::string& dccl_id_codec, const std::string& library_path)
-    : strict_(false), id_codec_(dccl_id_codec), console_width_(60)
+    : strict_(false), id_codec_(dccl_id_codec), console_width_(60), verbose_encode_errors_outputs_(false)
 {
     set_default_codecs();
     FieldCodecManager::add<DefaultIdentifierCodec>(default_id_codec_name());
@@ -204,8 +204,21 @@ void dccl::Codec::encode_internal(const google::protobuf::Message& msg, bool hea
         size_t head_byte_size = 0;
 
         if (!msg.IsInitialized() && !header_only)
-            throw(Exception(
-                "Message is not properly initialized. All `required` fields must be set."));
+        {
+            std::stringstream ss;
+
+            if (!verbose_encode_errors_outputs_)
+            {
+                ss << "Message is not properly initialized. All `required` fields must be set.";
+            }
+            else
+            {
+                ss << "Message is not properly initialized. All `required` fields must be set. Fields with errors: \n"
+                    << get_all_error_fields_in_message(msg);
+            }
+
+            throw(Exception(ss.str()));
+        }
 
         if (!id2desc_.count(dccl_id))
             throw(Exception("Message id " + boost::lexical_cast<std::string>(dccl_id) +
@@ -767,4 +780,81 @@ std::string dccl::Codec::build_guard_for_console_output(std::string& base, char 
 {
     // Only guard if possible, otherwise return an empty string rather than throwing a std::length_error.
     return (base.size() < console_width_) ? std::string((console_width_-base.size())/2, guard_char) : std::string();
+}
+
+
+std::string dccl::Codec::get_all_error_fields_in_message(
+    const google::protobuf::Message& message,
+    uint8_t depth /*= 1 */)
+{
+    // This is largely taken from google::protobuf::ReflectionOps::FindInitializationErrors(), which is called by
+    // google::protobuf::Message::FindInitializationErrors(). The Message implementation is not used as they force a
+    // prefix of parent message onto fields, which would require a split function to break by delimiter '.' should we
+    // want to reflect upon sub-messages and get field numbers.
+
+    std::stringstream output_stream;
+
+    const google::protobuf::Descriptor* descriptor = message.GetDescriptor();
+    const google::protobuf::Reflection* reflection = message.GetReflection();
+    const uint8_t depth_spacing = 4;
+
+    // Check required fields of this message.
+    const int32_t field_count = descriptor->field_count();
+
+    for (int32_t index = 0; index < field_count; ++index)
+    {
+        if (descriptor->field(index)->is_required())
+        {
+            if (!reflection->HasField(message, descriptor->field(index)))
+            {
+                output_stream << std::string(depth * depth_spacing, ' ')
+                    << descriptor->field(index)->number()
+                    << ": "
+                    << descriptor->field(index)->name()
+                    << "\n";
+            }
+        }
+    }
+
+    // Check sub-messages.
+    std::vector<const google::protobuf::FieldDescriptor*> fields;
+    reflection->ListFields(message, &fields);
+
+    for (const google::protobuf::FieldDescriptor* field : fields)
+    {
+        if (field->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE)
+        {
+            output_stream << std::string(depth * depth_spacing, ' ')
+                << field->number()
+                << ": "
+                << field->name()
+                << "\n";
+
+            if (field->is_repeated())
+            {
+                int32_t size = reflection->FieldSize(message, field);
+
+                for (int32_t index = 0; index < size; ++index)
+                {
+                    const google::protobuf::Message& sub_message =
+                        reflection->GetRepeatedMessage(message, field, index);
+
+                    output_stream << std::string((depth + 1) * depth_spacing, ' ')
+                        << "["
+                        << index
+                        << "]: "
+                        << "\n";
+
+                    output_stream << get_all_error_fields_in_message(sub_message, depth + 2);
+                }
+            }
+            else
+            {
+                const google::protobuf::Message& sub_message = reflection->GetMessage(message, field);
+                output_stream << get_all_error_fields_in_message(sub_message, depth + 1);
+            }
+        }
+    }
+
+    return output_stream.str();
 }

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -59,13 +59,12 @@ using google::protobuf::Descriptor;
 using google::protobuf::FieldDescriptor;
 using google::protobuf::Reflection;
 
-
 //
 // Codec
 //
 
 dccl::Codec::Codec(const std::string& dccl_id_codec, const std::string& library_path)
-    : strict_(false), id_codec_(dccl_id_codec), console_width_(60), verbose_encode_errors_outputs_(false)
+    : strict_(false), id_codec_(dccl_id_codec), console_width_(60)
 {
     set_default_codecs();
     FieldCodecManager::add<DefaultIdentifierCodec>(default_id_codec_name());
@@ -207,15 +206,9 @@ void dccl::Codec::encode_internal(const google::protobuf::Message& msg, bool hea
         {
             std::stringstream ss;
 
-            if (!verbose_encode_errors_outputs_)
-            {
-                ss << "Message is not properly initialized. All `required` fields must be set.";
-            }
-            else
-            {
-                ss << "Message is not properly initialized. All `required` fields must be set. Fields with errors: \n"
-                    << get_all_error_fields_in_message(msg);
-            }
+            ss << "Message is not properly initialized. All `required` fields must be set. Fields "
+                  "with errors: \n"
+               << get_all_error_fields_in_message(msg);
 
             throw(Exception(ss.str()));
         }
@@ -588,7 +581,8 @@ void dccl::Codec::info(const google::protobuf::Descriptor* desc, std::ostream* p
             const unsigned allowed_byte_size = desc->options().GetExtension(dccl::msg).max_bytes();
             const unsigned allowed_bit_size = allowed_byte_size * BITS_IN_BYTE;
 
-            std::string message_name = boost::lexical_cast<std::string>(dccl_id) + ": " + desc->full_name();
+            std::string message_name =
+                boost::lexical_cast<std::string>(dccl_id) + ": " + desc->full_name();
             std::string guard = build_guard_for_console_output(message_name, '=');
             std::string bits_dccl_head_str = "dccl.id head";
             std::string bits_user_head_str = "user head";
@@ -775,17 +769,16 @@ void dccl::Codec::set_id_codec(const std::string& id_codec_name)
     id_codec();
 }
 
-
 std::string dccl::Codec::build_guard_for_console_output(std::string& base, char guard_char) const
 {
     // Only guard if possible, otherwise return an empty string rather than throwing a std::length_error.
-    return (base.size() < console_width_) ? std::string((console_width_-base.size())/2, guard_char) : std::string();
+    return (base.size() < console_width_)
+               ? std::string((console_width_ - base.size()) / 2, guard_char)
+               : std::string();
 }
 
-
-std::string dccl::Codec::get_all_error_fields_in_message(
-    const google::protobuf::Message& message,
-    uint8_t depth /*= 1 */)
+std::string dccl::Codec::get_all_error_fields_in_message(const google::protobuf::Message& message,
+                                                         uint8_t depth /*= 1 */)
 {
     // This is largely taken from google::protobuf::ReflectionOps::FindInitializationErrors(), which is called by
     // google::protobuf::Message::FindInitializationErrors(). The Message implementation is not used as they force a
@@ -808,10 +801,8 @@ std::string dccl::Codec::get_all_error_fields_in_message(
             if (!reflection->HasField(message, descriptor->field(index)))
             {
                 output_stream << std::string(depth * depth_spacing, ' ')
-                    << descriptor->field(index)->number()
-                    << ": "
-                    << descriptor->field(index)->name()
-                    << "\n";
+                              << descriptor->field(index)->number() << ": "
+                              << descriptor->field(index)->name() << "\n";
             }
         }
     }
@@ -824,11 +815,8 @@ std::string dccl::Codec::get_all_error_fields_in_message(
     {
         if (field->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE)
         {
-            output_stream << std::string(depth * depth_spacing, ' ')
-                << field->number()
-                << ": "
-                << field->name()
-                << "\n";
+            output_stream << std::string(depth * depth_spacing, ' ') << field->number() << ": "
+                          << field->name() << "\n";
 
             if (field->is_repeated())
             {
@@ -839,18 +827,17 @@ std::string dccl::Codec::get_all_error_fields_in_message(
                     const google::protobuf::Message& sub_message =
                         reflection->GetRepeatedMessage(message, field, index);
 
-                    output_stream << std::string((depth + 1) * depth_spacing, ' ')
-                        << "["
-                        << index
-                        << "]: "
-                        << "\n";
+                    output_stream << std::string((depth + 1) * depth_spacing, ' ') << "[" << index
+                                  << "]: "
+                                  << "\n";
 
                     output_stream << get_all_error_fields_in_message(sub_message, depth + 2);
                 }
             }
             else
             {
-                const google::protobuf::Message& sub_message = reflection->GetMessage(message, field);
+                const google::protobuf::Message& sub_message =
+                    reflection->GetMessage(message, field);
                 output_stream << get_all_error_fields_in_message(sub_message, depth + 1);
             }
         }

--- a/src/codec.h
+++ b/src/codec.h
@@ -153,12 +153,6 @@ namespace dccl
         void set_console_width(unsigned num_chars) { console_width_ = num_chars; }
 
 
-        /// \brief Set "verbose_encode_errors_outputs_" where missing 'required' fields are recursively founds.
-        ///
-        /// \param mode "true" enables verbose errors on encode, "false" disables verbose errors on encode.
-        void set_verbose_encode_error_outputs(bool mode) { verbose_encode_errors_outputs_ = mode; }
-
-
         //@}
             
         /// \name Informational Methods.
@@ -392,9 +386,6 @@ namespace dccl
 
         // console outputting format width
         unsigned console_width_;
-
-        // recursive debug information in encode() with missing required fields
-        bool verbose_encode_errors_outputs_;
         
 	// set of DCCL IDs *not* to encrypt        
 	std::set<unsigned> skip_crypto_ids_;

--- a/src/codec.h
+++ b/src/codec.h
@@ -152,6 +152,13 @@ namespace dccl
         /// \param num_chars Character limit for line widths on console outputs
         void set_console_width(unsigned num_chars) { console_width_ = num_chars; }
 
+
+        /// \brief Set "verbose_encode_errors_outputs_" where missing 'required' fields are recursively founds.
+        ///
+        /// \param mode "true" enables verbose errors on encode, "false" disables verbose errors on encode.
+        void set_verbose_encode_error_outputs(bool mode) { verbose_encode_errors_outputs_ = mode; }
+
+
         //@}
             
         /// \name Informational Methods.
@@ -360,6 +367,9 @@ namespace dccl
         Codec& operator= (const Codec&);
 
         void encode_internal(const google::protobuf::Message& msg, bool header_only, Bitset& header_bits, Bitset& body_bits, int user_id);
+        std::string get_all_error_fields_in_message(
+            const google::protobuf::Message& msg,
+            uint8_t depth = 1);
 
         void encrypt(std::string* s, const std::string& nonce);
         void decrypt(std::string* s, const std::string& nonce);
@@ -382,6 +392,9 @@ namespace dccl
 
         // console outputting format width
         unsigned console_width_;
+
+        // recursive debug information in encode() with missing required fields
+        bool verbose_encode_errors_outputs_;
         
 	// set of DCCL IDs *not* to encrypt        
 	std::set<unsigned> skip_crypto_ids_;

--- a/src/test/dccl_all_fields/test.cpp
+++ b/src/test/dccl_all_fields/test.cpp
@@ -156,6 +156,20 @@ int main(int argc, char* argv[])
         {
         }
     }
+
+
+    // test verbose encode errors output
+    TestMsg empty;
+    try
+    {
+        std::string dummy;
+        codec.encode(&bytes, empty);
+    }
+    catch(const dccl::Exception&e)
+    {
+        // expected long error
+        std::cout << "Expected verbose error encoding empty message: " << e.what() << std::endl;
+    }    
     
     std::cout << "all tests passed" << std::endl;
 }


### PR DESCRIPTION
Added an optional verbose error output for encoding of required fields. Added a function for enabling said verbosity, akin to set_strict(). Should be no changes to default behaviour.

Field outputs are ordered by `field->number`, except for sub-messages (or similar fields) that appear at the end of the list, regardless of `field->number`. This _could_ be overcome in a hackish way by parsing the output stream prior to returning it on `depth==1` and manually ordering things? I can live without having to do that in C++.

Has been tested with:
All "standard" fields.
`oneof`
`repeated`
`sub-messages`

This should fix #93, @tsaubergine.