### PR TITLE
4.0 min repeat

### DIFF
--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -535,7 +535,9 @@ unsigned dccl::FieldCodecBase::min_size_repeated()
 
     if (codec_version() > 2)
         return repeated_vector_field_size(dccl_field_options().min_repeat(),
-                                          dccl_field_options().max_repeat());
+                                          dccl_field_options().max_repeat()) +
+               min_size() * dccl_field_options().min_repeat();
+
     else
         return min_size() * dccl_field_options().max_repeat();
 }

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -304,7 +304,11 @@ void dccl::FieldCodecBase::field_info(std::ostream* os,
                                              ". " + this_field()->name()
                                        : this_descriptor()->full_name());
     if (this_field() && this_field()->is_repeated())
-        name += "[" + boost::lexical_cast<std::string>(dccl_field_options().max_repeat()) + "]";
+        name += "[" +
+                (dccl_field_options().has_min_repeat()
+                     ? (boost::lexical_cast<std::string>(dccl_field_options().min_repeat()) + "-")
+                     : "") +
+                boost::lexical_cast<std::string>(dccl_field_options().max_repeat()) + "]";
 
     if (!this_field() || this_field()->type() == google::protobuf::FieldDescriptor::TYPE_MESSAGE)
         depth -= 1;
@@ -384,12 +388,23 @@ void dccl::FieldCodecBase::any_encode_repeated(dccl::Bitset* bits,
                                           FieldCodecBase::this_field()->DebugString(),
                                       this->this_field()));
 
+    if (wire_values.size() < dccl_field_options().min_repeat() && strict())
+        throw(dccl::OutOfRangeException(
+            std::string("Repeated size is less than min_repeat for field: ") +
+                FieldCodecBase::this_field()->DebugString(),
+            this->this_field()));
+
     // for DCCL3 and beyond, add a prefix numeric field giving the vector size (rather than always going to max_repeat)
     if (codec_version() > 2)
     {
-        wire_vector_size =
-            std::min((int)dccl_field_options().max_repeat(), (int)wire_values.size());
-        Bitset size_bits(repeated_vector_field_size(dccl_field_options().max_repeat()),
+        wire_vector_size = std::min(static_cast<int>(dccl_field_options().max_repeat()),
+                                    static_cast<int>(wire_values.size()));
+
+        wire_vector_size = std::max(static_cast<int>(dccl_field_options().min_repeat()),
+                                    static_cast<int>(wire_vector_size));
+
+        Bitset size_bits(repeated_vector_field_size(dccl_field_options().min_repeat(),
+                                                    dccl_field_options().max_repeat()),
                          wire_vector_size);
         bits->append(size_bits);
 
@@ -427,7 +442,8 @@ void dccl::FieldCodecBase::any_decode_repeated(Bitset* repeated_bits,
     if (codec_version() > 2)
     {
         Bitset size_bits(repeated_bits);
-        size_bits.get_more_bits(repeated_vector_field_size(dccl_field_options().max_repeat()));
+        size_bits.get_more_bits(repeated_vector_field_size(dccl_field_options().min_repeat(),
+                                                           dccl_field_options().max_repeat()));
 
         wire_vector_size = size_bits.to_ulong();
     }
@@ -461,9 +477,10 @@ unsigned dccl::FieldCodecBase::any_size_repeated(const std::vector<boost::any>& 
 
     if (codec_version() > 2)
     {
-        wire_vector_size =
-            std::min((int)dccl_field_options().max_repeat(), (int)wire_values.size());
-        out += repeated_vector_field_size(dccl_field_options().max_repeat());
+        wire_vector_size = std::min(static_cast<int>(dccl_field_options().max_repeat()),
+                                    static_cast<int>(wire_values.size()));
+        out += repeated_vector_field_size(dccl_field_options().min_repeat(),
+                                          dccl_field_options().max_repeat());
     }
 
     internal::MessageStack msg_handler(this->this_field());
@@ -493,7 +510,8 @@ unsigned dccl::FieldCodecBase::max_size_repeated()
         throw(Exception("Missing (dccl.field).max_repeat option on `repeated` field: " +
                         this_field()->DebugString()));
     else if (codec_version() > 2)
-        return repeated_vector_field_size(dccl_field_options().max_repeat()) +
+        return repeated_vector_field_size(dccl_field_options().min_repeat(),
+                                          dccl_field_options().max_repeat()) +
                max_size() * dccl_field_options().max_repeat();
     else
         return max_size() * dccl_field_options().max_repeat();
@@ -505,7 +523,8 @@ unsigned dccl::FieldCodecBase::min_size_repeated()
         throw(Exception("Missing (dccl.field).max_repeat option on `repeated` field " +
                         this_field()->DebugString()));
     else if (codec_version() > 2)
-        return repeated_vector_field_size(dccl_field_options().max_repeat());
+        return repeated_vector_field_size(dccl_field_options().min_repeat(),
+                                          dccl_field_options().max_repeat());
     else
         return min_size() * dccl_field_options().max_repeat();
 }

--- a/src/field_codec.h
+++ b/src/field_codec.h
@@ -466,6 +466,8 @@ class FieldCodecBase
     virtual unsigned max_size_repeated();
     virtual unsigned min_size_repeated();
 
+    void check_repeat_settings();
+    
     friend class FieldCodecManager;
 
   private:

--- a/src/field_codec.h
+++ b/src/field_codec.h
@@ -482,7 +482,10 @@ class FieldCodecBase
             return max_size() != min_size();
     }
 
-    int repeated_vector_field_size(int max_repeat) { return dccl::ceil_log2(max_repeat + 1); }
+    int repeated_vector_field_size(int min_repeat, int max_repeat)
+    {
+        return dccl::ceil_log2(max_repeat - min_repeat + 1);
+    }
 
     void disp_size(const google::protobuf::FieldDescriptor* field, const Bitset& new_bits,
                    int depth, int vector_size = -1);

--- a/src/option_extensions.proto
+++ b/src/option_extensions.proto
@@ -50,9 +50,10 @@ message DCCLFieldOptions
 
     // any `repeated` field
     optional uint32 max_repeat = 11 [default = 1];
+    optional uint32 min_repeat = 12 [default = 0];
 
     // enum
-    optional bool packed_enum = 12 [default = true];
+    optional bool packed_enum = 13 [default = true];
 
     optional string description = 20;
 

--- a/src/option_extensions.proto
+++ b/src/option_extensions.proto
@@ -36,8 +36,8 @@ message DCCLFieldOptions
     optional int32 precision = 4 [default = 0];   // Deprecated
     optional double resolution = 5 [default = 1];
     // int, double, float
-    optional double min = 6 [default = 0];
-    optional double max = 7 [default = 0];
+    optional double min = 6;
+    optional double max = 7;
 
     // time ("1 day" can encode times 12h before or after the receiver's time)
     optional uint32 num_days = 8 [default = 1];
@@ -46,10 +46,10 @@ message DCCLFieldOptions
     optional string static_value = 9 [default = ""];
 
     // string, bytes
-    optional uint32 max_length = 10 [default = 0];
+    optional uint32 max_length = 10;
 
     // any `repeated` field
-    optional uint32 max_repeat = 11 [default = 1];
+    optional uint32 max_repeat = 11;
     optional uint32 min_repeat = 12 [default = 0];
 
     // enum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(dccl_packed_enum)
 add_subdirectory(dccl_dynamic_protobuf)
 add_subdirectory(dccl_presence)
 add_subdirectory(dccl_resolution)
+add_subdirectory(dccl_min_repeat)
 
 if(enable_units)
   add_subdirectory(dccl_units)

--- a/src/test/dccl_min_repeat/CMakeLists.txt
+++ b/src/test/dccl_min_repeat/CMakeLists.txt
@@ -1,0 +1,4 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test.proto)
+add_executable(dccl_test_min_repeat test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(dccl_test_min_repeat dccl)
+add_test(dccl_test_min_repeat ${dccl_BIN_DIR}/dccl_test_min_repeat)

--- a/src/test/dccl_min_repeat/test.cpp
+++ b/src/test/dccl_min_repeat/test.cpp
@@ -1,0 +1,175 @@
+// Copyright 2009-2017 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (for 2013-)
+//                     Massachusetts Institute of Technology (for 2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
+// tests all protobuf types with _default codecs, repeat and non repeat
+
+#include <fstream>
+
+#include "dccl/native_protobuf/dccl_native_protobuf.h"
+#include <google/protobuf/descriptor.pb.h>
+
+#include "dccl/binary.h"
+#include "dccl/codec.h"
+#include "test.pb.h"
+using namespace dccl::test;
+
+dccl::Codec codec;
+
+int main(int argc, char* argv[])
+{
+    dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
+    codec.load<TestMsg>();
+    codec.info<TestMsg>();
+    {
+        TestMsg msg_in;
+        msg_in.add_a(0);
+        msg_in.add_a(1);
+        msg_in.add_a(2);
+
+        msg_in.add_b(10);
+        msg_in.add_b(11);
+
+        msg_in.add_c(20);
+        msg_in.add_c(21);
+        msg_in.add_c(22);
+
+        std::cout << "Message in:\n" << msg_in.DebugString() << std::endl;
+        std::cout << "Try encode..." << std::endl;
+        std::string bytes;
+        codec.encode(&bytes, msg_in);
+        std::cout << "... got bytes (hex): " << dccl::hex_encode(bytes) << std::endl;
+
+        std::cout << "Try decode..." << std::endl;
+        std::cout << codec.max_size(msg_in.GetDescriptor()) << std::endl;
+
+        TestMsg msg_out;
+        codec.decode(bytes, &msg_out);
+
+        std::cout << "... got Message out:\n" << msg_out.DebugString() << std::endl;
+        assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
+    }
+
+    {
+        TestMsg msg_in;
+        msg_in.add_a(0);
+        msg_in.add_a(1);
+        msg_in.add_a(2);
+        msg_in.add_a(3);
+        msg_in.add_a(4);
+        msg_in.add_a(5);
+
+        msg_in.add_b(10);
+        msg_in.add_b(11);
+
+        msg_in.add_c(20);
+        msg_in.add_c(21);
+        msg_in.add_c(22);
+
+        std::cout << "Message in:\n" << msg_in.DebugString() << std::endl;
+        std::cout << "Try encode..." << std::endl;
+        std::string bytes;
+        codec.encode(&bytes, msg_in);
+        std::cout << "... got bytes (hex): " << dccl::hex_encode(bytes) << std::endl;
+
+        std::cout << "Try decode..." << std::endl;
+        std::cout << codec.max_size(msg_in.GetDescriptor()) << std::endl;
+
+        TestMsg msg_out;
+        codec.decode(bytes, &msg_out);
+
+        msg_in.mutable_a()->RemoveLast();
+
+        std::cout << "... got Message out:\n" << msg_out.DebugString() << std::endl;
+        assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
+    }
+
+    {
+        TestMsg msg_in;
+        msg_in.add_a(0);
+        msg_in.add_a(1);
+        msg_in.add_a(2);
+        msg_in.add_a(3);
+        msg_in.add_a(4);
+
+        msg_in.add_c(20);
+        msg_in.add_c(21);
+        msg_in.add_c(22);
+
+        std::cout << "Message in:\n" << msg_in.DebugString() << std::endl;
+        std::cout << "Try encode..." << std::endl;
+        std::string bytes;
+        codec.encode(&bytes, msg_in);
+        std::cout << "... got bytes (hex): " << dccl::hex_encode(bytes) << std::endl;
+
+        std::cout << "Try decode..." << std::endl;
+        std::cout << codec.max_size(msg_in.GetDescriptor()) << std::endl;
+
+        TestMsg msg_out;
+        codec.decode(bytes, &msg_out);
+
+        auto bmin = dccl::test::TestMsg::descriptor()
+                        ->FindFieldByName("b")
+                        ->options()
+                        .GetExtension(dccl::field)
+                        .min();
+        msg_in.add_b(bmin);
+        msg_in.add_b(bmin);
+
+        std::cout << "... got Message out:\n" << msg_out.DebugString() << std::endl;
+        assert(msg_in.SerializeAsString() == msg_out.SerializeAsString());
+    }
+
+    try
+    {
+        // should throw exception on missing max repeat
+        codec.load<InvalidTestMsgMissingMaxRepeat>();
+        assert(false);
+    }
+    catch (const dccl::Exception& e)
+    {
+        // expected
+    }
+
+    try
+    {
+        // should throw exception
+        codec.load<InvalidTestMsgMaxRepeatLessThanOne>();
+        assert(false);
+    }
+    catch (const dccl::Exception& e)
+    {
+        // expected
+    }
+
+    try
+    {
+        // should throw exception
+        codec.load<InvalidTestMsgMaxRepeatLessThanMinRepeat>();
+        assert(false);
+    }
+    catch (const dccl::Exception& e)
+    {
+        // expected
+    }
+
+    
+    std::cout << "All tests passed." << std::endl;
+}

--- a/src/test/dccl_min_repeat/test.proto
+++ b/src/test/dccl_min_repeat/test.proto
@@ -1,0 +1,58 @@
+@PROTOBUF_SYNTAX_VERSION@
+
+import "dccl/option_extensions.proto";
+
+package dccl.test;
+
+message TestMsg
+{
+    option (dccl.msg) = {
+        id: 1
+        max_bytes: 32
+        codec_version: 4
+    };
+
+    repeated int32 a = 1 [
+        (dccl.field) = { min: -100 max: 100 max_repeat: 5 }
+    ];  // default min repeat (0)
+    repeated int32 b = 2 [
+        (dccl.field) = { min: -100 max: 100 min_repeat: 2 max_repeat: 3 }
+    ];  // min repeat and max repeat different
+    repeated int32 c = 3 [
+        (dccl.field) = { min: -100 max: 100 min_repeat: 3 max_repeat: 3 }
+    ];  // min repeat and max repeat the same
+}
+
+message InvalidTestMsgMissingMaxRepeat
+{
+    option (dccl.msg) = {
+        id: 2
+        max_bytes: 32
+        codec_version: 4
+    };
+
+    repeated int32 a = 1 [(dccl.field) = { min: -100 max: 100 }];
+}
+
+message InvalidTestMsgMaxRepeatLessThanOne
+{
+    option (dccl.msg) = {
+        id: 2
+        max_bytes: 32
+        codec_version: 4
+    };
+
+    repeated int32 a = 1 [(dccl.field) = { min: -100 max: 100 max_repeat: 0 }];
+}
+
+message InvalidTestMsgMaxRepeatLessThanMinRepeat
+{
+    option (dccl.msg) = {
+        id: 2
+        max_bytes: 32
+        codec_version: 4
+    };
+
+    repeated int32 a = 1
+        [(dccl.field) = { min: -100 max: 100 min_repeat: 5 max_repeat: 3 }];
+}


### PR DESCRIPTION
Adds new option `min_repeat` for repeated fields (defaults to zero to preserve existing behavior).

Closes #90.