### PR TITLE
Fixed DCCL CLI ignoring --messages with --dlopen

### DIFF
--- a/src/apps/dccl/dccl_tool.cpp
+++ b/src/apps/dccl/dccl_tool.cpp
@@ -197,7 +197,23 @@ int main(int argc, char* argv[])
     }
 }
 
-void analyze(dccl::Codec& dccl, const dccl::tool::Config& /*cfg*/) { dccl.info_all(&std::cout); }
+void analyze(dccl::Codec& codec, const dccl::tool::Config& cfg)
+{
+    if (cfg.message.size() == 0)
+    {
+        codec.info_all(&std::cout);
+    }
+    else
+    {
+        for (const auto &it : cfg.message)
+        {
+            const google::protobuf::Descriptor* desc =
+                dccl::DynamicProtobufManager::find_descriptor(it);
+
+            codec.info(desc, &std::cout);
+        }
+    }
+}
 
 void encode(dccl::Codec& dccl, dccl::tool::Config& cfg)
 {


### PR DESCRIPTION
#106 exposed unwanted behaviour in the DCCL CLI application. Calling ```dccl --dlopen /path/to/shared/library.so --analyze``` dumped the entire library contents to terminal, ignoring the ```--messages``` flag. This fixes that behaviour.