### PR TITLE
Changed bitset operator overloads from bitwise operators to logical assignments.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -585,7 +585,7 @@ jobs:
           command: |
             mkdir -p build && cd build &&
             scan-build --use-cc=/usr/bin/clang --use-c++=/usr/bin/clang++ cmake .. -Denable_testing=ON -DCMAKE_BUILD_TYPE=Debug &&
-            scan-build --exclude /usr/include/boost --use-cc=/usr/bin/clang --use-c++=/usr/bin/clang++ --status-bugs cmake --build . -- -j${SANITIZER_NUM_JOBS}
+            scan-build --exclude /usr/include/boost --exclude src/thirdparty --use-cc=/usr/bin/clang --use-c++=/usr/bin/clang++ --status-bugs cmake --build . -- -j${SANITIZER_NUM_JOBS}
       - run:
           name: Store static analyzer results
           command: cd /tmp && tar cfvz scan-build.tar.gz scan-build*

--- a/src/bitset.h
+++ b/src/bitset.h
@@ -78,7 +78,7 @@ class Bitset : public std::deque<bool>
         if (rhs.size() != size())
             throw(dccl::Exception("Bitset operator&= requires this->size() == rhs.size()"));
 
-        for (size_type i = 0; i != this->size(); ++i) (*this)[i] = (*this)[i] & rhs[i];
+        for (size_type i = 0; i != this->size(); ++i) (*this)[i] &= rhs[i];
         return *this;
     }
 
@@ -93,7 +93,7 @@ class Bitset : public std::deque<bool>
         if (rhs.size() != size())
             throw(dccl::Exception("Bitset operator|= requires this->size() == rhs.size()"));
 
-        for (size_type i = 0; i != this->size(); ++i) (*this)[i] = (*this)[i] | rhs[i];
+        for (size_type i = 0; i != this->size(); ++i) (*this)[i] |= rhs[i];
         return *this;
     }
 
@@ -108,7 +108,7 @@ class Bitset : public std::deque<bool>
         if (rhs.size() != size())
             throw(dccl::Exception("Bitset operator^= requires this->size() == rhs.size()"));
 
-        for (size_type i = 0; i != this->size(); ++i) (*this)[i] = (*this)[i] ^ rhs[i];
+        for (size_type i = 0; i != this->size(); ++i) (*this)[i] ^= rhs[i];
         return *this;
     }
 


### PR DESCRIPTION
Changed the Bitset ```&=```, ```|=```, and ```^=``` operator overloads to logical assignments instead of bitwise operators to fix ```scan``` warnings.

Since C++11, these are guaranteed to be equivalent operations, except LHS is only evaluated once instead of twice.