### PR TITLE
revert option extension numbering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,7 +588,7 @@ jobs:
           command: |
             mkdir -p build && cd build &&
             scan-build --use-cc=/usr/bin/clang --use-c++=/usr/bin/clang++ cmake .. -Denable_testing=ON -DCMAKE_BUILD_TYPE=Debug &&
-            scan-build --exclude /usr/include/boost --use-cc=/usr/bin/clang --use-c++=/usr/bin/clang++ --status-bugs cmake --build . -- -j${SANITIZER_NUM_JOBS}
+            scan-build --exclude /usr/include/boost --exclude src/thirdparty --use-cc=/usr/bin/clang --use-c++=/usr/bin/clang++ --status-bugs cmake --build . -- -j${SANITIZER_NUM_JOBS}
       - run:
           name: Store static analyzer results
           command: cd /tmp && tar cfvz scan-build.tar.gz scan-build*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,8 @@ jobs:
           command: brew install cmake protobuf@21
       - run: &run-build
           name: Build
-          command: mkdir -p build && cd build && cmake -Denable_testing=ON -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . -- -j4
+          command: |
+            mkdir -p build && cd build && cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/protobuf@21 -Denable_testing=ON -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . -- -j4
       - run: &run-tests
           name: Run tests
           command: cd build && ctest --output-on-failure -j4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,8 @@ jobs:
           command: brew update
       - run:
           name: Install CMake
-          command: brew install cmake protobuf
+          # Protobuf@23 has CMake linking problems with abseil that we don't yet support
+          command: brew install cmake protobuf@21
       - run: &run-build
           name: Build
           command: mkdir -p build && cd build && cmake -Denable_testing=ON -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . -- -j4

--- a/src/option_extensions.proto
+++ b/src/option_extensions.proto
@@ -59,26 +59,26 @@ message DCCLFieldOptions
 
     // double, float
     optional int32 precision = 4 [default = 0];  // Deprecated
-    optional double resolution = 5 [default = 1];
+    optional double resolution = 12 [default = 1];
     // int, double, float
-    optional double min = 6;
-    optional double max = 7;
+    optional double min = 5;
+    optional double max = 6;
 
     // time ("1 day" can encode times 12h before or after the receiver's time)
-    optional uint32 num_days = 8 [default = 1];
+    optional uint32 num_days = 7 [default = 1];
 
     // static
-    optional string static_value = 9 [default = ""];
+    optional string static_value = 8 [default = ""];
 
     // string, bytes
-    optional uint32 max_length = 10;
+    optional uint32 max_length = 9;
 
     // any `repeated` field
-    optional uint32 max_repeat = 11;
-    optional uint32 min_repeat = 12 [default = 0];
+    optional uint32 max_repeat = 10;
+    optional uint32 min_repeat = 13 [default = 0];
 
     // enum
-    optional bool packed_enum = 13 [default = true];
+    optional bool packed_enum = 11 [default = true];
 
     optional string description = 20;
 


### PR DESCRIPTION
This change in 4.0.3 was causing log parsing problems in Goby. Better to revert it now than cause further issues.