### PR TITLE
Add custom clock to TimeCodec. Improve codec search by trying version as well

### DIFF
--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -59,6 +59,10 @@
 #include "codecs4/field_codec_var_bytes.h"
 #include "field_codec_id.h"
 
+#include "codecs2/default_field_codec_impl.h"
+#include "codecs3/default_field_codec_impl.h"
+#include "codecs4/default_field_codec_impl.h"
+
 #include "option_extensions.pb.h"
 
 using dccl::hex_encode;
@@ -100,108 +104,37 @@ void dccl::Codec::set_default_codecs()
     using google::protobuf::FieldDescriptor;
 
     // version 2
-    manager_.add<v2::DefaultNumericFieldCodec<double>>(default_codec_name(2));
-    manager_.add<v2::DefaultNumericFieldCodec<float>>(default_codec_name(2));
-    manager_.add<v2::DefaultBoolCodec>(default_codec_name(2));
-    manager_.add<v2::DefaultNumericFieldCodec<int32>>(default_codec_name(2));
-    manager_.add<v2::DefaultNumericFieldCodec<int64>>(default_codec_name(2));
-    manager_.add<v2::DefaultNumericFieldCodec<uint32>>(default_codec_name(2));
-    manager_.add<v2::DefaultNumericFieldCodec<uint64>>(default_codec_name(2));
-    manager_.add<v2::DefaultStringCodec, FieldDescriptor::TYPE_STRING>(default_codec_name(2));
-    manager_.add<v2::DefaultBytesCodec, FieldDescriptor::TYPE_BYTES>(default_codec_name(2));
-    manager_.add<v2::DefaultEnumCodec>(default_codec_name(2));
-    manager_.add<v2::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(default_codec_name(2));
+    DefaultFieldCodecAdder<2>::add<0, double, float, int32, int64, uint32, uint64>(manager_);
+    add_time_field_codecs<2, double, int64, uint64>(manager_);
+    add_static_field_codecs<2, std::string, double, float, int32, int64, uint32, uint64>(manager_);
 
-    manager_.add<v2::TimeCodec<uint64>>("dccl.time2");
-    manager_.add<v2::TimeCodec<int64>>("dccl.time2");
-    manager_.add<v2::TimeCodec<double>>("dccl.time2");
-
-    manager_.add<v2::StaticCodec<std::string>>("dccl.static2");
-    manager_.add<v2::StaticCodec<double>>("dccl.static2");
-    manager_.add<v2::StaticCodec<float>>("dccl.static2");
-    manager_.add<v2::StaticCodec<int32>>("dccl.static2");
-    manager_.add<v2::StaticCodec<int64>>("dccl.static2");
-    manager_.add<v2::StaticCodec<uint32>>("dccl.static2");
-    manager_.add<v2::StaticCodec<uint64>>("dccl.static2");
-
+    //
     // version 3
-    manager_.add<v3::DefaultNumericFieldCodec<double>>(default_codec_name(3));
-    manager_.add<v3::DefaultNumericFieldCodec<float>>(default_codec_name(3));
-    manager_.add<v3::DefaultBoolCodec>(default_codec_name(3));
-    manager_.add<v3::DefaultNumericFieldCodec<int32>>(default_codec_name(3));
-    manager_.add<v3::DefaultNumericFieldCodec<int64>>(default_codec_name(3));
-    manager_.add<v3::DefaultNumericFieldCodec<uint32>>(default_codec_name(3));
-    manager_.add<v3::DefaultNumericFieldCodec<uint64>>(default_codec_name(3));
-    manager_.add<v3::DefaultStringCodec, FieldDescriptor::TYPE_STRING>(default_codec_name(3));
-    manager_.add<v3::DefaultBytesCodec, FieldDescriptor::TYPE_BYTES>(default_codec_name(3));
-    manager_.add<v3::DefaultEnumCodec>(default_codec_name(3));
-    manager_.add<v3::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(default_codec_name(3));
-
-    manager_.add<v3::TimeCodec<uint64>>("dccl.time3");
-    manager_.add<v3::TimeCodec<int64>>("dccl.time3");
-    manager_.add<v3::TimeCodec<double>>("dccl.time3");
-
-    manager_.add<v3::StaticCodec<std::string>>("dccl.static3");
-    manager_.add<v3::StaticCodec<double>>("dccl.static3");
-    manager_.add<v3::StaticCodec<float>>("dccl.static3");
-    manager_.add<v3::StaticCodec<int32>>("dccl.static3");
-    manager_.add<v3::StaticCodec<int64>>("dccl.static3");
-    manager_.add<v3::StaticCodec<uint32>>("dccl.static3");
-    manager_.add<v3::StaticCodec<uint64>>("dccl.static3");
-
+    //
+    DefaultFieldCodecAdder<3>::add<0, double, float, int32, int64, uint32, uint64>(manager_);
+    add_time_field_codecs<3, double, int64, uint64>(manager_);
+    add_static_field_codecs<3, std::string, double, float, int32, int64, uint32, uint64>(manager_);
     // presence bit codec, which encode empty optional fields with a single bit
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<double>>>("dccl.presence3");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<float>>>("dccl.presence3");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<int32>>>("dccl.presence3");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<int64>>>("dccl.presence3");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<uint32>>>("dccl.presence3");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<uint64>>>("dccl.presence3");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultEnumCodec>>("dccl.presence3");
-
+    add_presence_field_codecs<3, double, float, int32, int64, uint32, uint64>(manager_);
     // alternative bytes codec that more efficiently encodes variable length bytes fields
     manager_.add<v3::VarBytesCodec, FieldDescriptor::TYPE_BYTES>("dccl.var_bytes3");
 
+    //
     // version 4
-    manager_.add<v4::DefaultNumericFieldCodec<double>>(default_codec_name(4));
-    manager_.add<v4::DefaultNumericFieldCodec<float>>(default_codec_name(4));
-    manager_.add<v4::DefaultBoolCodec>(default_codec_name(4));
-    manager_.add<v4::DefaultNumericFieldCodec<int32>>(default_codec_name(4));
-    manager_.add<v4::DefaultNumericFieldCodec<int64>>(default_codec_name(4));
-    manager_.add<v4::DefaultNumericFieldCodec<uint32>>(default_codec_name(4));
-    manager_.add<v4::DefaultNumericFieldCodec<uint64>>(default_codec_name(4));
-    manager_.add<v4::DefaultStringCodec, FieldDescriptor::TYPE_STRING>(default_codec_name(4));
-    manager_.add<v4::DefaultBytesCodec, FieldDescriptor::TYPE_BYTES>(default_codec_name(4));
-    manager_.add<v4::DefaultEnumCodec>(default_codec_name(4));
-    manager_.add<v4::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(default_codec_name(4));
-
-    manager_.add<v4::TimeCodec<uint64>>("dccl.time4");
-    manager_.add<v4::TimeCodec<int64>>("dccl.time4");
-    manager_.add<v4::TimeCodec<double>>("dccl.time4");
-
-    manager_.add<v4::StaticCodec<std::string>>("dccl.static4");
-    manager_.add<v4::StaticCodec<double>>("dccl.static4");
-    manager_.add<v4::StaticCodec<float>>("dccl.static4");
-    manager_.add<v4::StaticCodec<int32>>("dccl.static4");
-    manager_.add<v4::StaticCodec<int64>>("dccl.static4");
-    manager_.add<v4::StaticCodec<uint32>>("dccl.static4");
-    manager_.add<v4::StaticCodec<uint64>>("dccl.static4");
-
-    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<double>>>("dccl.presence4");
-    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<float>>>("dccl.presence4");
-    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<int32>>>("dccl.presence4");
-    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<int64>>>("dccl.presence4");
-    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<uint32>>>("dccl.presence4");
-    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<uint64>>>("dccl.presence4");
-    manager_.add<v4::PresenceBitCodec<v4::DefaultEnumCodec>>("dccl.presence4");
-
+    //
+    DefaultFieldCodecAdder<4>::add<0, double, float, int32, int64, uint32, uint64>(manager_);
+    add_time_field_codecs<4, double, int64, uint64>(manager_);
+    add_static_field_codecs<4, std::string, double, float, int32, int64, uint32, uint64>(manager_);
+    add_presence_field_codecs<4, double, float, int32, int64, uint32, uint64>(manager_);
     manager_.add<v4::VarBytesCodec, FieldDescriptor::TYPE_BYTES>("dccl.var_bytes4");
-
     // hash codec - backport for older versions
     manager_.add<v4::HashCodec>("dccl.hash2");
     manager_.add<v4::HashCodec>("dccl.hash3");
     manager_.add<v4::HashCodec>("dccl.hash4");
 
-    // for backwards compatibility
+    //
+    // for backwards compatibility (deprecated)
+    //
     manager_.add<v2::TimeCodec<uint64>>("_time");
     manager_.add<v2::TimeCodec<int64>>("_time");
     manager_.add<v2::TimeCodec<double>>("_time");

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -97,33 +97,35 @@ void dccl::Codec::set_default_codecs()
 {
     using google::protobuf::FieldDescriptor;
 
+    //
     // version 2
-    DefaultFieldCodecLoader<2>::add(manager_);
-    TimeCodecLoader<2>::add(manager_);
-    StaticCodecLoader<2>::add(manager_);
+    //
+    internal::DefaultFieldCodecLoader<2>::add(manager_);
+    internal::TimeCodecLoader<2>::add(manager_);
+    internal::StaticCodecLoader<2>::add(manager_);
 
     // backwards compatibility names (deprecated)
-    TimeCodecLoader<2>::add(manager_, "_time");
-    StaticCodecLoader<2>::add(manager_, "_static");
+    internal::TimeCodecLoader<2>::add(manager_, "_time");
+    internal::StaticCodecLoader<2>::add(manager_, "_static");
 
     //
     // version 3
     //
-    DefaultFieldCodecLoader<3>::add(manager_);
-    TimeCodecLoader<3>::add(manager_);
-    StaticCodecLoader<3>::add(manager_);
-    PresenceCodecLoader<3>::add(manager_);
-    VarBytesCodecLoader<3>::add(manager_);
+    internal::DefaultFieldCodecLoader<3>::add(manager_);
+    internal::TimeCodecLoader<3>::add(manager_);
+    internal::StaticCodecLoader<3>::add(manager_);
+    internal::PresenceCodecLoader<3>::add(manager_);
+    internal::VarBytesCodecLoader<3>::add(manager_);
 
     //
     // version 4
     //
-    DefaultFieldCodecLoader<4>::add(manager_);
-    TimeCodecLoader<4>::add(manager_);
-    StaticCodecLoader<4>::add(manager_);
-    PresenceCodecLoader<4>::add(manager_);
-    VarBytesCodecLoader<4>::add(manager_);
-    HashCodecLoader<4>::add(manager_, {2, 3, 4}); // backport for older versions 2 and 3
+    internal::DefaultFieldCodecLoader<4>::add(manager_);
+    internal::TimeCodecLoader<4>::add(manager_);
+    internal::StaticCodecLoader<4>::add(manager_);
+    internal::PresenceCodecLoader<4>::add(manager_);
+    internal::VarBytesCodecLoader<4>::add(manager_);
+    internal::HashCodecLoader<4>::add(manager_, {2, 3, 4}); // backport for older versions 2 and 3
 }
 
 void dccl::Codec::encode_internal(const google::protobuf::Message& msg, bool header_only,

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -48,14 +48,8 @@
 #endif // CRYPTOPP_PATH_USES_PLUS_SIGN
 #endif // HAS_CRYPTOPP
 
-#include "codecs2/field_codec_default.h"
-#include "codecs3/field_codec_default.h"
-#include "codecs3/field_codec_presence.h"
 #include "codecs3/field_codec_var_bytes.h"
-#include "codecs4/field_codec_default.h"
-#include "codecs4/field_codec_default_message.h"
 #include "codecs4/field_codec_hash.h"
-#include "codecs4/field_codec_presence.h"
 #include "codecs4/field_codec_var_bytes.h"
 #include "field_codec_id.h"
 
@@ -104,48 +98,32 @@ void dccl::Codec::set_default_codecs()
     using google::protobuf::FieldDescriptor;
 
     // version 2
-    DefaultFieldCodecAdder<2>::add<0, double, float, int32, int64, uint32, uint64>(manager_);
-    add_time_field_codecs<2, double, int64, uint64>(manager_);
-    add_static_field_codecs<2, std::string, double, float, int32, int64, uint32, uint64>(manager_);
+    DefaultFieldCodecLoader<2>::add(manager_);
+    TimeCodecLoader<2>::add(manager_);
+    StaticCodecLoader<2>::add(manager_);
+
+    // backwards compatibility names (deprecated)
+    TimeCodecLoader<2>::add(manager_, "_time");
+    StaticCodecLoader<2>::add(manager_, "_static");
 
     //
     // version 3
     //
-    DefaultFieldCodecAdder<3>::add<0, double, float, int32, int64, uint32, uint64>(manager_);
-    add_time_field_codecs<3, double, int64, uint64>(manager_);
-    add_static_field_codecs<3, std::string, double, float, int32, int64, uint32, uint64>(manager_);
-    // presence bit codec, which encode empty optional fields with a single bit
-    add_presence_field_codecs<3, double, float, int32, int64, uint32, uint64>(manager_);
-    // alternative bytes codec that more efficiently encodes variable length bytes fields
-    manager_.add<v3::VarBytesCodec, FieldDescriptor::TYPE_BYTES>("dccl.var_bytes3");
+    DefaultFieldCodecLoader<3>::add(manager_);
+    TimeCodecLoader<3>::add(manager_);
+    StaticCodecLoader<3>::add(manager_);
+    PresenceCodecLoader<3>::add(manager_);
+    VarBytesCodecLoader<3>::add(manager_);
 
     //
     // version 4
     //
-    DefaultFieldCodecAdder<4>::add<0, double, float, int32, int64, uint32, uint64>(manager_);
-    add_time_field_codecs<4, double, int64, uint64>(manager_);
-    add_static_field_codecs<4, std::string, double, float, int32, int64, uint32, uint64>(manager_);
-    add_presence_field_codecs<4, double, float, int32, int64, uint32, uint64>(manager_);
-    manager_.add<v4::VarBytesCodec, FieldDescriptor::TYPE_BYTES>("dccl.var_bytes4");
-    // hash codec - backport for older versions
-    manager_.add<v4::HashCodec>("dccl.hash2");
-    manager_.add<v4::HashCodec>("dccl.hash3");
-    manager_.add<v4::HashCodec>("dccl.hash4");
-
-    //
-    // for backwards compatibility (deprecated)
-    //
-    manager_.add<v2::TimeCodec<uint64>>("_time");
-    manager_.add<v2::TimeCodec<int64>>("_time");
-    manager_.add<v2::TimeCodec<double>>("_time");
-
-    manager_.add<v2::StaticCodec<std::string>>("_static");
-    manager_.add<v2::StaticCodec<double>>("_static");
-    manager_.add<v2::StaticCodec<float>>("_static");
-    manager_.add<v2::StaticCodec<int32>>("_static");
-    manager_.add<v2::StaticCodec<int64>>("_static");
-    manager_.add<v2::StaticCodec<uint32>>("_static");
-    manager_.add<v2::StaticCodec<uint64>>("_static");
+    DefaultFieldCodecLoader<4>::add(manager_);
+    TimeCodecLoader<4>::add(manager_);
+    StaticCodecLoader<4>::add(manager_);
+    PresenceCodecLoader<4>::add(manager_);
+    VarBytesCodecLoader<4>::add(manager_);
+    HashCodecLoader<4>::add(manager_, {2, 3, 4}); // backport for older versions 2 and 3
 }
 
 void dccl::Codec::encode_internal(const google::protobuf::Message& msg, bool header_only,

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -55,6 +55,8 @@
 #include "codecs4/field_codec_default.h"
 #include "codecs4/field_codec_default_message.h"
 #include "codecs4/field_codec_hash.h"
+#include "codecs4/field_codec_presence.h"
+#include "codecs4/field_codec_var_bytes.h"
 #include "field_codec_id.h"
 
 #include "option_extensions.pb.h"
@@ -98,17 +100,17 @@ void dccl::Codec::set_default_codecs()
     using google::protobuf::FieldDescriptor;
 
     // version 2
-    manager_.add<v2::DefaultNumericFieldCodec<double>>(default_codec_name());
-    manager_.add<v2::DefaultNumericFieldCodec<float>>(default_codec_name());
-    manager_.add<v2::DefaultBoolCodec>(default_codec_name());
-    manager_.add<v2::DefaultNumericFieldCodec<int32>>(default_codec_name());
-    manager_.add<v2::DefaultNumericFieldCodec<int64>>(default_codec_name());
-    manager_.add<v2::DefaultNumericFieldCodec<uint32>>(default_codec_name());
-    manager_.add<v2::DefaultNumericFieldCodec<uint64>>(default_codec_name());
-    manager_.add<v2::DefaultStringCodec, FieldDescriptor::TYPE_STRING>(default_codec_name());
-    manager_.add<v2::DefaultBytesCodec, FieldDescriptor::TYPE_BYTES>(default_codec_name());
-    manager_.add<v2::DefaultEnumCodec>(default_codec_name());
-    manager_.add<v2::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(default_codec_name());
+    manager_.add<v2::DefaultNumericFieldCodec<double>>(default_codec_name(2));
+    manager_.add<v2::DefaultNumericFieldCodec<float>>(default_codec_name(2));
+    manager_.add<v2::DefaultBoolCodec>(default_codec_name(2));
+    manager_.add<v2::DefaultNumericFieldCodec<int32>>(default_codec_name(2));
+    manager_.add<v2::DefaultNumericFieldCodec<int64>>(default_codec_name(2));
+    manager_.add<v2::DefaultNumericFieldCodec<uint32>>(default_codec_name(2));
+    manager_.add<v2::DefaultNumericFieldCodec<uint64>>(default_codec_name(2));
+    manager_.add<v2::DefaultStringCodec, FieldDescriptor::TYPE_STRING>(default_codec_name(2));
+    manager_.add<v2::DefaultBytesCodec, FieldDescriptor::TYPE_BYTES>(default_codec_name(2));
+    manager_.add<v2::DefaultEnumCodec>(default_codec_name(2));
+    manager_.add<v2::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(default_codec_name(2));
 
     manager_.add<v2::TimeCodec<uint64>>("dccl.time2");
     manager_.add<v2::TimeCodec<int64>>("dccl.time2");
@@ -135,6 +137,30 @@ void dccl::Codec::set_default_codecs()
     manager_.add<v3::DefaultEnumCodec>(default_codec_name(3));
     manager_.add<v3::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(default_codec_name(3));
 
+    manager_.add<v3::TimeCodec<uint64>>("dccl.time3");
+    manager_.add<v3::TimeCodec<int64>>("dccl.time3");
+    manager_.add<v3::TimeCodec<double>>("dccl.time3");
+
+    manager_.add<v3::StaticCodec<std::string>>("dccl.static3");
+    manager_.add<v3::StaticCodec<double>>("dccl.static3");
+    manager_.add<v3::StaticCodec<float>>("dccl.static3");
+    manager_.add<v3::StaticCodec<int32>>("dccl.static3");
+    manager_.add<v3::StaticCodec<int64>>("dccl.static3");
+    manager_.add<v3::StaticCodec<uint32>>("dccl.static3");
+    manager_.add<v3::StaticCodec<uint64>>("dccl.static3");
+
+    // presence bit codec, which encode empty optional fields with a single bit
+    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<double>>>("dccl.presence3");
+    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<float>>>("dccl.presence3");
+    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<int32>>>("dccl.presence3");
+    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<int64>>>("dccl.presence3");
+    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<uint32>>>("dccl.presence3");
+    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<uint64>>>("dccl.presence3");
+    manager_.add<v3::PresenceBitCodec<v3::DefaultEnumCodec>>("dccl.presence3");
+
+    // alternative bytes codec that more efficiently encodes variable length bytes fields
+    manager_.add<v3::VarBytesCodec, FieldDescriptor::TYPE_BYTES>("dccl.var_bytes3");
+
     // version 4
     manager_.add<v4::DefaultNumericFieldCodec<double>>(default_codec_name(4));
     manager_.add<v4::DefaultNumericFieldCodec<float>>(default_codec_name(4));
@@ -148,20 +174,32 @@ void dccl::Codec::set_default_codecs()
     manager_.add<v4::DefaultEnumCodec>(default_codec_name(4));
     manager_.add<v4::DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(default_codec_name(4));
 
-    // presence bit codec, which encode empty optional fields with a single bit
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<double>>>("dccl.presence");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<float>>>("dccl.presence");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<int32>>>("dccl.presence");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<int64>>>("dccl.presence");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<uint32>>>("dccl.presence");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<uint64>>>("dccl.presence");
-    manager_.add<v3::PresenceBitCodec<v3::DefaultEnumCodec>>("dccl.presence");
+    manager_.add<v4::TimeCodec<uint64>>("dccl.time4");
+    manager_.add<v4::TimeCodec<int64>>("dccl.time4");
+    manager_.add<v4::TimeCodec<double>>("dccl.time4");
 
-    // hash codec
-    manager_.add<v4::HashCodec>("dccl.hash");
+    manager_.add<v4::StaticCodec<std::string>>("dccl.static4");
+    manager_.add<v4::StaticCodec<double>>("dccl.static4");
+    manager_.add<v4::StaticCodec<float>>("dccl.static4");
+    manager_.add<v4::StaticCodec<int32>>("dccl.static4");
+    manager_.add<v4::StaticCodec<int64>>("dccl.static4");
+    manager_.add<v4::StaticCodec<uint32>>("dccl.static4");
+    manager_.add<v4::StaticCodec<uint64>>("dccl.static4");
 
-    // alternative bytes codec that more efficiently encodes variable length bytes fields
-    manager_.add<v3::VarBytesCodec, FieldDescriptor::TYPE_BYTES>("dccl.var_bytes");
+    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<double>>>("dccl.presence4");
+    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<float>>>("dccl.presence4");
+    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<int32>>>("dccl.presence4");
+    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<int64>>>("dccl.presence4");
+    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<uint32>>>("dccl.presence4");
+    manager_.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<uint64>>>("dccl.presence4");
+    manager_.add<v4::PresenceBitCodec<v4::DefaultEnumCodec>>("dccl.presence4");
+
+    manager_.add<v4::VarBytesCodec, FieldDescriptor::TYPE_BYTES>("dccl.var_bytes4");
+
+    // hash codec - backport for older versions
+    manager_.add<v4::HashCodec>("dccl.hash2");
+    manager_.add<v4::HashCodec>("dccl.hash3");
+    manager_.add<v4::HashCodec>("dccl.hash4");
 
     // for backwards compatibility
     manager_.add<v2::TimeCodec<uint64>>("_time");

--- a/src/codec.h
+++ b/src/codec.h
@@ -49,6 +49,7 @@
 #include "codecs2/field_codec_default_message.h"
 #include "codecs3/field_codec_default_message.h"
 #include "dccl/def.h"
+#include "dccl/version.h"
 #include "field_codec_manager.h"
 
 /// Dynamic Compact Control Language namespace
@@ -368,14 +369,7 @@ class Codec
 
     static std::string default_codec_name(int version = 2)
     {
-        switch (version)
-        {
-            case 2:
-                return dccl::DCCLFieldOptions::descriptor()
-                    ->FindFieldByName("codec")
-                    ->default_value_string();
-            default: return "dccl.default" + std::to_string(version);
-        }
+        return "dccl.default" + std::to_string(version);
     }
 
     FieldCodecManagerLocal& manager() { return manager_; }
@@ -393,7 +387,8 @@ class Codec
 
     std::shared_ptr<FieldCodecBase> id_codec() const
     {
-        return manager_.find(google::protobuf::FieldDescriptor::TYPE_UINT32, id_codec_);
+        return manager_.find(google::protobuf::FieldDescriptor::TYPE_UINT32, DCCL_VERSION_MAJOR,
+                             id_codec_);
     }
 
   private:

--- a/src/codecs2/default_field_codec_impl.h
+++ b/src/codecs2/default_field_codec_impl.h
@@ -1,4 +1,7 @@
 #define CODEC_VERSION 2
 #define CODEC_VERSION_NAMESPACE v2
 
+#include "field_codec_default.h"
+#include "field_codec_default_message.h"
+
 #include "../default_field_codec.h"

--- a/src/codecs2/default_field_codec_impl.h
+++ b/src/codecs2/default_field_codec_impl.h
@@ -1,0 +1,4 @@
+#define CODEC_VERSION 2
+#define CODEC_VERSION_NAMESPACE v2
+
+#include "../default_field_codec.h"

--- a/src/codecs2/default_field_codec_impl.h
+++ b/src/codecs2/default_field_codec_impl.h
@@ -1,7 +1,7 @@
 #define CODEC_VERSION 2
-#define CODEC_VERSION_NAMESPACE v2
+#define CODEC_VERSION_NAMESPACE ::dccl::v2
 
 #include "field_codec_default.h"
 #include "field_codec_default_message.h"
 
-#include "../default_field_codec.h"
+#include "../internal/default_field_codec.h"

--- a/src/codecs2/field_codec_default.cpp
+++ b/src/codecs2/field_codec_default.cpp
@@ -28,6 +28,12 @@
 #include "../codec.h"
 #include "field_codec_default.h"
 
+#if DCCL_THREAD_SUPPORT
+std::mutex dccl::v2::TimeCodecClock::clock_mutex_;
+#endif
+
+std::function<dccl::int64()> dccl::v2::TimeCodecClock::epoch_sec_func_;
+
 using namespace dccl::logger;
 
 //

--- a/src/codecs2/field_codec_default.h
+++ b/src/codecs2/field_codec_default.h
@@ -255,11 +255,12 @@ class DefaultNumericFieldCodec : public TypedFixedFieldCodec<WireType, FieldType
 /// [presence bit (0 bits if required, 1 bit if optional)][value (1 bit)]
 class DefaultBoolCodec : public TypedFixedFieldCodec<bool>
 {
-  private:
+  public:
     Bitset encode(const bool& wire_value) override;
     Bitset encode() override;
     bool decode(Bitset* bits) override;
     unsigned size() override;
+    unsigned size(const bool& wire_value) override { return size(); }
     void validate() override;
 };
 
@@ -288,7 +289,7 @@ class DefaultStringCodec : public TypedFieldCodec<std::string>
 /// \brief Provides an fixed length byte string encoder.
 class DefaultBytesCodec : public TypedFieldCodec<std::string>
 {
-  private:
+  public:
     Bitset encode() override;
     Bitset encode(const std::string& wire_value) override;
     std::string decode(Bitset* bits) override;

--- a/src/codecs2/field_codec_default.h
+++ b/src/codecs2/field_codec_default.h
@@ -30,7 +30,7 @@
 #ifndef DCCLFIELDCODECDEFAULT20110322H
 #define DCCLFIELDCODECDEFAULT20110322H
 
-#include <sys/time.h>
+#include <chrono>
 
 #include <google/protobuf/descriptor.h>
 
@@ -39,6 +39,7 @@
 #include "../binary.h"
 #include "../field_codec.h"
 #include "../field_codec_fixed.h"
+#include "../thread_safety.h"
 #include "field_codec_default_message.h"
 
 namespace dccl
@@ -312,7 +313,7 @@ class DefaultEnumCodec
     {
         return std::hash<std::string>{}(this_field()->enum_type()->DebugString());
     }
-    
+
     double max() override
     {
         const google::protobuf::EnumDescriptor* e = this_field()->enum_type();
@@ -321,14 +322,65 @@ class DefaultEnumCodec
     double min() override { return 0; }
 };
 
+class TimeCodecClock
+{
+  public:
+    TimeCodecClock()
+    {
+        // if no other clock, set std::chrono::system_clock as clock
+        if (!this->has_clock())
+            this->set_clock<std::chrono::system_clock>();
+    }
+
+    template <typename Clock> static void set_clock()
+    {
+#if DCCL_THREAD_SUPPORT
+        const std::lock_guard<std::mutex> lock(clock_mutex_);
+#endif
+
+        epoch_sec_func_ = []() -> int64
+        {
+            typename Clock::time_point now = Clock::now();
+            std::chrono::seconds sec =
+                std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
+            return sec.count();
+        };
+    }
+    static bool has_clock()
+    {
+#if DCCL_THREAD_SUPPORT
+        const std::lock_guard<std::mutex> lock(clock_mutex_);
+#endif
+        return epoch_sec_func_ ? true : false;
+    }
+
+  protected:
+    static int64 epoch_sec()
+    {
+#if DCCL_THREAD_SUPPORT
+        const std::lock_guard<std::mutex> lock(clock_mutex_);
+#endif
+        return epoch_sec_func_();
+    }
+
+  private:
+#if DCCL_THREAD_SUPPORT
+    static std::mutex clock_mutex_;
+#endif
+    static std::function<int64()> epoch_sec_func_;
+};
+
 typedef double time_wire_type;
 /// \brief Encodes time of day (default: second precision, but can be set with (dccl.field).precision extension)
 ///
 /// \tparam TimeType A type representing time: See the various specializations of this class for allowed types.
 template <typename TimeType, int conversion_factor>
-class TimeCodecBase : public DefaultNumericFieldCodec<time_wire_type, TimeType>
+class TimeCodecBase : public DefaultNumericFieldCodec<time_wire_type, TimeType>,
+                      public TimeCodecClock
 {
   public:
+    TimeCodecBase() {}
+
     time_wire_type pre_encode(const TimeType& time_of_day) override
     {
         time_wire_type max_secs = max();
@@ -337,22 +389,16 @@ class TimeCodecBase : public DefaultNumericFieldCodec<time_wire_type, TimeType>
 
     TimeType post_decode(const time_wire_type& encoded_time) override
     {
-        auto max_secs = (int64)max();
-        timeval t;
-        gettimeofday(&t, nullptr);
-        int64 now = t.tv_sec;
-        int64 daystart = now - (now % max_secs);
-        int64 today_time = now - daystart;
+        auto max_secs = static_cast<int64>(max());
+        int64_t now_secs = this->epoch_sec();
+        int64 daystart = now_secs - (now_secs % max_secs);
+        int64 today_time = now_secs - daystart;
 
         // If time is more than 12 hours ahead of now, assume it's yesterday.
         if ((encoded_time - today_time) > (max_secs / 2))
-        {
             daystart -= max_secs;
-        }
         else if ((today_time - encoded_time) > (max_secs / 2))
-        {
             daystart += max_secs;
-        }
 
         return dccl::round((TimeType)(conversion_factor * (daystart + encoded_time)),
                            precision() - std::log10((double)conversion_factor));

--- a/src/codecs2/field_codec_default_message.h
+++ b/src/codecs2/field_codec_default_message.h
@@ -46,7 +46,7 @@ class DefaultMessageCodec : public FieldCodecBase
 
     std::shared_ptr<FieldCodecBase> find(const google::protobuf::FieldDescriptor* field_desc)
     {
-        return manager().find(field_desc, has_codec_group(), codec_group());
+        return manager().find(field_desc, this->codec_version(), has_codec_group(), codec_group());
     }
 
     void validate() override;
@@ -133,7 +133,6 @@ class DefaultMessageCodec : public FieldCodecBase
         }
     };
 
-    
     template <typename Action, typename ReturnType>
     void traverse_descriptor(ReturnType* return_value)
     {

--- a/src/codecs3/default_field_codec_impl.h
+++ b/src/codecs3/default_field_codec_impl.h
@@ -1,4 +1,8 @@
 #define CODEC_VERSION 3
 #define CODEC_VERSION_NAMESPACE v3
 
+#include "field_codec_default.h"
+#include "field_codec_default_message.h"
+#include "field_codec_presence.h"
+
 #include "../default_field_codec.h"

--- a/src/codecs3/default_field_codec_impl.h
+++ b/src/codecs3/default_field_codec_impl.h
@@ -1,0 +1,4 @@
+#define CODEC_VERSION 3
+#define CODEC_VERSION_NAMESPACE v3
+
+#include "../default_field_codec.h"

--- a/src/codecs3/default_field_codec_impl.h
+++ b/src/codecs3/default_field_codec_impl.h
@@ -1,8 +1,8 @@
 #define CODEC_VERSION 3
-#define CODEC_VERSION_NAMESPACE v3
+#define CODEC_VERSION_NAMESPACE ::dccl::v3
 
 #include "field_codec_default.h"
 #include "field_codec_default_message.h"
 #include "field_codec_presence.h"
 
-#include "../default_field_codec.h"
+#include "../internal/default_field_codec.h"

--- a/src/codecs3/field_codec_default.h
+++ b/src/codecs3/field_codec_default.h
@@ -37,9 +37,10 @@ namespace v3
 {
 // all these are the same as version 2
 template <typename WireType, typename FieldType = WireType>
-class DefaultNumericFieldCodec : public v2::DefaultNumericFieldCodec<WireType, FieldType>
-{
-};
+using DefaultNumericFieldCodec = v2::DefaultNumericFieldCodec<WireType, FieldType>;
+
+template <typename TimeType> using TimeCodec = v2::TimeCodec<TimeType>;
+template <typename T> using StaticCodec = v2::StaticCodec<T>;
 
 using DefaultBoolCodec = v2::DefaultBoolCodec;
 using DefaultBytesCodec = v2::DefaultBytesCodec;
@@ -66,25 +67,6 @@ class DefaultEnumCodec
   private:
     double max() override;
     double min() override;
-};
-
-template <typename TimeType> class TimeCodec : public v2::TimeCodecBase<TimeType, 0>
-{
-    static_assert(sizeof(TimeCodec) == 0, "Must use specialization of TimeCodec");
-};
-
-template <> class TimeCodec<uint64> : public v2::TimeCodecBase<uint64, 1000000>
-{
-};
-template <> class TimeCodec<int64> : public v2::TimeCodecBase<int64, 1000000>
-{
-};
-template <> class TimeCodec<double> : public v2::TimeCodecBase<double, 1>
-{
-};
-
-template <typename T> class StaticCodec : public v2::StaticCodec<T>
-{
 };
 
 /// \brief Provides an variable length ASCII string encoder.

--- a/src/codecs3/field_codec_default.h
+++ b/src/codecs3/field_codec_default.h
@@ -74,7 +74,8 @@ class DefaultEnumCodec
 /// [length of following string size: ceil(log2(max_length))][string]
 class DefaultStringCodec : public TypedFieldCodec<std::string>
 {
-  private:
+  public:
+    void validate() override;
     Bitset encode() override;
     Bitset encode(const std::string& wire_value) override;
     std::string decode(Bitset* bits) override;
@@ -82,7 +83,6 @@ class DefaultStringCodec : public TypedFieldCodec<std::string>
     unsigned size(const std::string& wire_value) override;
     unsigned max_size() override;
     unsigned min_size() override;
-    void validate() override;
 };
 
 } // namespace v3

--- a/src/codecs3/field_codec_default_message.h
+++ b/src/codecs3/field_codec_default_message.h
@@ -46,7 +46,7 @@ class DefaultMessageCodec : public FieldCodecBase
 
     std::shared_ptr<FieldCodecBase> find(const google::protobuf::FieldDescriptor* field_desc)
     {
-        return manager().find(field_desc, has_codec_group(), codec_group());
+        return manager().find(field_desc, this->codec_version(), has_codec_group(), codec_group());
     }
 
     bool is_optional() { return this_field() && this_field()->is_optional(); }

--- a/src/codecs3/field_codec_var_bytes.h
+++ b/src/codecs3/field_codec_var_bytes.h
@@ -35,7 +35,7 @@ namespace v3
 // if repeated: [M bits - prefix with the number of repeated values][same as "required" for value with index 0][same as "required" for index = 1]...[same as required for last index]
 class VarBytesCodec : public dccl::TypedFieldCodec<std::string>
 {
-  private:
+  public:
     dccl::Bitset encode() override;
     dccl::Bitset encode(const std::string& wire_value) override;
     std::string decode(dccl::Bitset* bits) override;

--- a/src/codecs4/default_field_codec_impl.h
+++ b/src/codecs4/default_field_codec_impl.h
@@ -1,0 +1,4 @@
+#define CODEC_VERSION 4
+#define CODEC_VERSION_NAMESPACE v4
+
+#include "../default_field_codec.h"

--- a/src/codecs4/default_field_codec_impl.h
+++ b/src/codecs4/default_field_codec_impl.h
@@ -1,8 +1,8 @@
 #define CODEC_VERSION 4
-#define CODEC_VERSION_NAMESPACE v4
+#define CODEC_VERSION_NAMESPACE ::dccl::v4
 
 #include "field_codec_default.h"
 #include "field_codec_default_message.h"
 #include "field_codec_presence.h"
 
-#include "../default_field_codec.h"
+#include "../internal/default_field_codec.h"

--- a/src/codecs4/default_field_codec_impl.h
+++ b/src/codecs4/default_field_codec_impl.h
@@ -1,4 +1,8 @@
 #define CODEC_VERSION 4
 #define CODEC_VERSION_NAMESPACE v4
 
+#include "field_codec_default.h"
+#include "field_codec_default_message.h"
+#include "field_codec_presence.h"
+
 #include "../default_field_codec.h"

--- a/src/codecs4/field_codec_default_message.h
+++ b/src/codecs4/field_codec_default_message.h
@@ -48,7 +48,7 @@ class DefaultMessageCodec : public FieldCodecBase
 
     std::shared_ptr<FieldCodecBase> find(const google::protobuf::FieldDescriptor* field_desc)
     {
-        return manager().find(field_desc, has_codec_group(), codec_group());
+        return manager().find(field_desc, this->codec_version(), has_codec_group(), codec_group());
     }
 
     bool is_optional() { return this_field() && this_field()->is_optional() && !use_required(); }
@@ -261,9 +261,9 @@ class DefaultMessageCodec : public FieldCodecBase
             // Add oneof field's info
             for (auto i = 0; i < oneof_desc->field_count(); ++i)
             {
-                auto codec = field_codec->manager().find(oneof_desc->field(i),
-                                                         field_codec->has_codec_group(),
-                                                         field_codec->codec_group());
+                auto codec = field_codec->manager().find(
+                    oneof_desc->field(i), field_codec->codec_version(),
+                    field_codec->has_codec_group(), field_codec->codec_group());
                 codec->field_info(return_value, oneof_desc->field(i));
             }
 

--- a/src/codecs4/field_codec_presence.h
+++ b/src/codecs4/field_codec_presence.h
@@ -1,0 +1,36 @@
+// Copyright 2019:
+//   GobySoft, LLC (2013-)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Kyle Guilbert <kguilbert@aphysci.com>
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
+#ifndef FIELD_CODEC4_PRESENCE_H
+#define FIELD_CODEC4_PRESENCE_H
+
+#include "../codecs3/field_codec_presence.h"
+
+namespace dccl
+{
+namespace v4
+{
+template <typename WrappedType> using PresenceBitCodec = v3::PresenceBitCodec<WrappedType>;
+} // namespace v4
+} // namespace dccl
+
+#endif

--- a/src/codecs4/field_codec_var_bytes.h
+++ b/src/codecs4/field_codec_var_bytes.h
@@ -1,9 +1,7 @@
-// Copyright 2009-2022:
+// Copyright 2018:
 //   GobySoft, LLC (2013-)
-//   Massachusetts Institute of Technology (2007-2014)
 //   Community contributors (see AUTHORS file)
 // File authors:
-//   Davide Fenucci <davfen@noc.ac.uk>
 //   Toby Schneider <toby@gobysoft.org>
 //
 //
@@ -22,32 +20,16 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
-// implements FieldCodecBase for all the basic DCCL types for version 3
+#ifndef FIELD_CODEC4_VAR_BYTES_H
+#define FIELD_CODEC4_VAR_BYTES_H
 
-#ifndef DCCLV4FIELDCODECDEFAULT20210701H
-#define DCCLV4FIELDCODECDEFAULT20210701H
-
-#include "../codecs3/field_codec_default.h"
 #include "../codecs3/field_codec_var_bytes.h"
 
 namespace dccl
 {
-/// DCCL version 4 default field codecs
 namespace v4
 {
-// all these are the same as version 3
-template <typename WireType, typename FieldType = WireType>
-using DefaultNumericFieldCodec = v3::DefaultNumericFieldCodec<WireType, FieldType>;
-
-using DefaultBoolCodec = v3::DefaultBoolCodec;
-using DefaultEnumCodec = v3::DefaultEnumCodec;
-
-using DefaultBytesCodec = v3::VarBytesCodec;
-using DefaultStringCodec = v3::VarBytesCodec;
-
-template <typename TimeType> using TimeCodec = v3::TimeCodec<TimeType>;
-template <typename T> using StaticCodec = v3::StaticCodec<T>;
-
+using VarBytesCodec = v3::VarBytesCodec;
 } // namespace v4
 } // namespace dccl
 

--- a/src/default_field_codec.h
+++ b/src/default_field_codec.h
@@ -1,0 +1,131 @@
+// Copyright 2023:
+//   GobySoft, LLC (2013-)
+//   Massachusetts Institute of Technology (2007-2014)
+//   Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Dynamic Compact Control Language Library
+// ("DCCL").
+//
+// DCCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// DCCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "codec.h"
+
+#ifndef CODEC_VERSION
+#error CODEC_VERSION must be set
+#endif
+
+#ifndef CODEC_VERSION_NAMESPACE
+#error CODEC_VERSION_NAMESPACE must be set
+#endif
+
+#ifndef DCCL_DEFAULT_FIELD_CODEC_HEADER_H
+#define DCCL_DEFAULT_FIELD_CODEC_HEADER_H
+
+namespace dccl
+{
+//
+// Helper functions to reduce copy/paste in set_default_codecs()
+//
+template <int version> struct DefaultFieldCodecAdder
+{
+    template <int dummy> static void add(FieldCodecManagerLocal& manager);
+    template <int dummy, typename T, typename... Types>
+    static void add(FieldCodecManagerLocal& manager);
+};
+
+template <int version> void add_time_field_codecs(FieldCodecManagerLocal& manager) {}
+template <int version, typename T, typename... Types>
+void add_time_field_codecs(FieldCodecManagerLocal& manager)
+{
+    std::string name = "dccl.time" + std::to_string(version);
+    switch (version)
+    {
+        case 2: manager.add<v2::TimeCodec<T>>(name); break;
+        case 3: manager.add<v3::TimeCodec<T>>(name); break;
+        case 4: manager.add<v4::TimeCodec<T>>(name); break;
+    }
+    add_time_field_codecs<version, Types...>(manager);
+}
+
+template <int version> void add_static_field_codecs(FieldCodecManagerLocal& manager) {}
+template <int version, typename T, typename... Types>
+void add_static_field_codecs(FieldCodecManagerLocal& manager)
+{
+    std::string name = "dccl.static" + std::to_string(version);
+    switch (version)
+    {
+        case 2: manager.add<v2::StaticCodec<T>>(name); break;
+        case 3: manager.add<v3::StaticCodec<T>>(name); break;
+        case 4: manager.add<v4::StaticCodec<T>>(name); break;
+    }
+    add_static_field_codecs<version, Types...>(manager);
+}
+
+template <int version> void add_presence_field_codecs(FieldCodecManagerLocal& manager)
+{
+    std::string name = "dccl.presence" + std::to_string(version);
+    switch (version)
+    {
+        case 3: manager.add<v3::PresenceBitCodec<v3::DefaultEnumCodec>>(name); break;
+        case 4: manager.add<v4::PresenceBitCodec<v4::DefaultEnumCodec>>(name); break;
+    }
+}
+template <int version, typename T, typename... Types>
+void add_presence_field_codecs(FieldCodecManagerLocal& manager)
+{
+    std::string name = "dccl.presence" + std::to_string(version);
+    switch (version)
+    {
+        case 3: manager.add<v3::PresenceBitCodec<v3::DefaultNumericFieldCodec<T>>>(name); break;
+        case 4: manager.add<v4::PresenceBitCodec<v4::DefaultNumericFieldCodec<T>>>(name); break;
+    }
+    add_presence_field_codecs<version, Types...>(manager);
+}
+} // namespace dccl
+#endif
+
+namespace dccl
+{
+
+template <>
+template <int dummy>
+void DefaultFieldCodecAdder<CODEC_VERSION>::add(FieldCodecManagerLocal& manager)
+{
+    using namespace CODEC_VERSION_NAMESPACE;
+    using google::protobuf::FieldDescriptor;
+
+    std::string name = dccl::Codec::default_codec_name(CODEC_VERSION);
+    manager.add<DefaultBoolCodec>(name);
+    manager.add<DefaultStringCodec, FieldDescriptor::TYPE_STRING>(name);
+    manager.add<DefaultBytesCodec, FieldDescriptor::TYPE_BYTES>(name);
+    manager.add<DefaultEnumCodec>(name);
+    manager.add<DefaultMessageCodec, FieldDescriptor::TYPE_MESSAGE>(name);
+}
+
+template <>
+template <int dummy, typename T, typename... Types>
+void DefaultFieldCodecAdder<CODEC_VERSION>::add(FieldCodecManagerLocal& manager)
+{
+    using namespace CODEC_VERSION_NAMESPACE;
+    std::string name = dccl::Codec::default_codec_name(CODEC_VERSION);
+    manager.add<DefaultNumericFieldCodec<T>>(name);
+    // recurse
+    add<0, Types...>(manager);
+}
+
+} // namespace dccl
+
+#undef CODEC_VERSION
+#undef CODEC_VERSION_NAMESPACE

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -338,7 +338,7 @@ void dccl::FieldCodecBase::field_info(std::ostream* os,
     int width = this_field() ? full_width - name.size() : full_width - name.size() + spaces;
     ss << indent << name << std::setfill('.') << std::setw(std::max(1, width)) << range.str()
        << " {"
-       << (this_field() ? manager().find(this_field(), has_codec_group(), codec_group())->name()
+       << (this_field() ? manager().find(this_field(), codec_version(), has_codec_group(), codec_group())->name()
                         : manager().find(manager().codec_data().root_descriptor_)->name())
        << "}";
 

--- a/src/field_codec_manager.cpp
+++ b/src/field_codec_manager.cpp
@@ -23,30 +23,62 @@
 // along with DCCL.  If not, see <http://www.gnu.org/licenses/>.
 #include "field_codec_manager.h"
 
-dccl::FieldCodecManagerLocal::FieldCodecManagerLocal() = default;
+dccl::FieldCodecManagerLocal::FieldCodecManagerLocal()
+    : deprecated_names_{{"_static", "dccl.static"}, {"_time", "dccl.time"}}
+{
+}
 
 dccl::FieldCodecManagerLocal::~FieldCodecManagerLocal() = default;
 
 std::shared_ptr<dccl::FieldCodecBase>
 dccl::FieldCodecManagerLocal::__find(google::protobuf::FieldDescriptor::Type type,
-                                     const std::string& codec_name,
-                                     const std::string& type_name /* = "" */) const
+                                     int codec_version, const std::string& codec_name,
+                                     const std::string& type_name) const
 {
+    check_deprecated(codec_name);
+
     auto it = codecs_.find(type);
+
+    std::vector<std::string> codec_names_to_try;
     if (it != codecs_.end())
     {
         auto inside_it = it->second.end();
-        // try specific type codec
-        inside_it = it->second.find(__mangle_name(codec_name, type_name));
-        if (inside_it != it->second.end())
-            return inside_it->second;
 
-        // try general
-        inside_it = it->second.find(codec_name);
-        if (inside_it != it->second.end())
-            return inside_it->second;
+        // try appending codec_version first
+        if (!std::isdigit(codec_name.back()))
+            codec_names_to_try.push_back(codec_name + std::to_string(codec_version));
+
+        codec_names_to_try.push_back(codec_name);
+
+        for (const std::string& c_name : codec_names_to_try)
+        {
+            // try specific type codec
+            inside_it = it->second.find(__mangle_name(c_name, type_name));
+            if (inside_it != it->second.end())
+                return inside_it->second;
+
+            // try general
+            inside_it = it->second.find(c_name);
+            if (inside_it != it->second.end())
+                return inside_it->second;
+        }
     }
 
-    throw(Exception("No codec by the name `" + codec_name +
-                    "` found for type: " + type_helper().find(type)->as_str()));
+    std::stringstream err_ss;
+    err_ss << "No codec by the name `" << codec_name
+           << "` found for type: " << type_helper().find(type)->as_str() << " (tried names:";
+    for (const std::string& c_name : codec_names_to_try) err_ss << " `" << c_name << "`";
+    err_ss << ")";
+    throw(Exception(err_ss.str()));
+}
+
+void dccl::FieldCodecManagerLocal::check_deprecated(const std::string& codec_name) const
+{
+    auto it = deprecated_names_.find(codec_name);
+    if (it != deprecated_names_.end())
+    {
+        dlog.is(dccl::logger::DEBUG1) && dlog << "Codec name \"" << it->first
+                                              << "\" is deprecated: use \"" << it->second
+                                              << "\" instead " << std::endl;
+    }
 }

--- a/src/field_codec_manager.h
+++ b/src/field_codec_manager.h
@@ -112,14 +112,15 @@ class FieldCodecManagerLocal
 
     /// \brief Find the codec for a given field. For embedded messages, prefers (dccl.field).codec (inside field) over (dccl.msg).codec (inside embedded message).
     std::shared_ptr<FieldCodecBase> find(const google::protobuf::FieldDescriptor* field,
-                                         bool has_codec_group, const std::string& codec_group) const
+                                         int codec_version, bool has_codec_group,
+                                         const std::string& codec_group) const
     {
         std::string name = __find_codec(field, has_codec_group, codec_group);
 
         if (field->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE)
-            return find(field->message_type(), name);
+            return find(field->message_type(), codec_version, name);
         else
-            return __find(field->type(), name);
+            return __find(field->type(), codec_version, name, "");
     }
 
     /// \brief Find the codec for a given base (or embedded) message.
@@ -127,7 +128,7 @@ class FieldCodecManagerLocal
     /// \param desc Message descriptor to find codec for
     /// \param name Codec name (used for embedded messages to prefer the codec listed as a field option). Omit for finding the codec of a base message (one that is not embedded).
     std::shared_ptr<FieldCodecBase> find(const google::protobuf::Descriptor* desc,
-                                         std::string name = "") const
+                                         int codec_version = 0, std::string name = "") const
     {
         // this was called on the root message
         if (name.empty())
@@ -137,15 +138,17 @@ class FieldCodecManagerLocal
                 name = desc->options().GetExtension(dccl::msg).codec();
             else
                 name = FieldCodecBase::codec_group(desc);
+            codec_version = desc->options().GetExtension(dccl::msg).codec_version();
         }
 
-        return __find(google::protobuf::FieldDescriptor::TYPE_MESSAGE, name, desc->full_name());
+        return __find(google::protobuf::FieldDescriptor::TYPE_MESSAGE, codec_version, name,
+                      desc->full_name());
     }
 
     std::shared_ptr<FieldCodecBase> find(google::protobuf::FieldDescriptor::Type type,
-                                         std::string name) const
+                                         int codec_version, std::string name) const
     {
-        return __find(type, name);
+        return __find(type, codec_version, name, "");
     }
 
     void clear()
@@ -169,8 +172,8 @@ class FieldCodecManagerLocal
 
   private:
     std::shared_ptr<FieldCodecBase> __find(google::protobuf::FieldDescriptor::Type type,
-                                           const std::string& codec_name,
-                                           const std::string& type_name = "") const;
+                                           int codec_version, const std::string& codec_name,
+                                           const std::string& type_name) const;
 
     std::string __mangle_name(const std::string& codec_name, const std::string& type_name) const
     {
@@ -217,6 +220,8 @@ class FieldCodecManagerLocal
             return dccl_field_options.codec();
     }
 
+    void check_deprecated(const std::string& name) const;
+
   private:
     using InsideMap = std::map<std::string, std::shared_ptr<FieldCodecBase>>;
     std::map<google::protobuf::FieldDescriptor::Type, InsideMap> codecs_;
@@ -225,6 +230,7 @@ class FieldCodecManagerLocal
     internal::CodecData codec_data_;
 
     std::map<const google::protobuf::Descriptor*, std::size_t> hashes_;
+    std::map<std::string, std::string> deprecated_names_;
 };
 
 class FieldCodecManager

--- a/src/test/dccl_header/header.proto
+++ b/src/test/dccl_header/header.proto
@@ -37,20 +37,20 @@ message Header
     // microseconds since Unix
 
     // second precision (default)
-    required uint64 time = 10 [(dccl.field).codec = "_time"];
+    required uint64 time = 10 [(dccl.field).codec = "dccl.time"];
 
-    optional int64 time_signed = 20 [(dccl.field).codec = "_time"];
-    optional double time_double = 21 [(dccl.field).codec = "_time"];
+    optional int64 time_signed = 20 [(dccl.field).codec = "dccl.time"];
+    optional double time_double = 21 [(dccl.field).codec = "dccl.time"];
     optional double pasttime_double = 22
-        [(dccl.field).codec = "_time", (dccl.field).num_days = 6];
+        [(dccl.field).codec = "dccl.time", (dccl.field).num_days = 6];
     optional double futuretime_double = 23
-        [(dccl.field).codec = "_time", (dccl.field).num_days = 6];
+        [(dccl.field).codec = "dccl.time", (dccl.field).num_days = 6];
 
     // microsecond precision
     optional int64 time_precision = 24
-        [(dccl.field).codec = "_time", (dccl.field).precision = -3];
+        [(dccl.field).codec = "dccl.time", (dccl.field).precision = -3];
     optional double time_double_precision = 25
-        [(dccl.field).codec = "_time", (dccl.field).precision = 6];
+        [(dccl.field).codec = "dccl.time", (dccl.field).precision = 6];
 
     //
     // source

--- a/src/test/dccl_header/test.proto
+++ b/src/test/dccl_header/test.proto
@@ -37,5 +37,14 @@ message GobyMessage
     required Header header = 2 [(dccl.field).in_head = true];
 
     optional int32 const_int = 3
-        [(dccl.field).static_value = "3", (dccl.field).codec = "_static"];
+        [(dccl.field).static_value = "3", (dccl.field).codec = "dccl.static"];
+}
+
+message TimeTest
+{
+    option (dccl.msg).id = 4;
+    option (dccl.msg).max_bytes = 64;
+    option (dccl.msg).codec_version = 4;
+    
+    required uint64 time = 1 [(dccl.field).codec = "dccl.time"];
 }

--- a/src/test/dccl_presence/test.cpp
+++ b/src/test/dccl_presence/test.cpp
@@ -26,11 +26,10 @@
 #include "test/dccl_presence/test.pb.h"
 using namespace dccl::test;
 
-
 void test1(dccl::Codec&);
 void test2(dccl::Codec&);
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
     dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
 
@@ -106,6 +105,9 @@ void test2(dccl::Codec& codec)
     msg_in.set_opt_float(-900.12345);
     msg_in.set_opt_double(900.12345678);
     msg_in.set_opt_enum(ENUM2_A);
+    msg_in.set_opt_bool(true);
+    msg_in.set_opt_str("ABCDE");
+    msg_in.set_opt_bytes("XY");
 
     msg_in.add_repeat_i32(500);
     msg_in.add_repeat_enum(ENUM2_A);
@@ -115,7 +117,7 @@ void test2(dccl::Codec& codec)
     std::string encoded;
     codec.encode(&encoded, msg_in);
 
-    assert(encoded.size() == 33);
+    assert(encoded.size() == 41);
 
     PresenceMsg msg_out;
     codec.decode(encoded, &msg_out);

--- a/src/test/dccl_presence/test.proto
+++ b/src/test/dccl_presence/test.proto
@@ -35,64 +35,39 @@ enum Enum
 message PresenceMsg
 {
     option (dccl.msg).id = 10;
-    option (dccl.msg).max_bytes = 54;
+    option (dccl.msg).max_bytes = 64;
     option (dccl.msg).codec_version = 4;
+    option (dccl.msg).codec_group = "dccl.presence";
 
-    // optional fields gain an extra bit set to 1
-    required int32 req_i32 = 1
-        [(dccl.field) = { codec: "dccl.presence", min: -100, max: 500 }];
-    required int64 req_i64 = 2
-        [(dccl.field) = { codec: "dccl.presence", min: 0, max: 65535 }];
-    required uint32 req_ui32 = 3
-        [(dccl.field) = { codec: "dccl.presence", min: 0, max: 1022 }];
-    required uint64 req_ui64 = 4
-        [(dccl.field) = { codec: "dccl.presence", min: 100, max: 1123 }];
-    required float req_float = 5 [(dccl.field) = {
-        codec: "dccl.presence",
-        min: -1000,
-        max: 1000,
-        precision: 5
-    }];
-    required double req_double = 6 [(dccl.field) = {
-        codec: "dccl.presence",
-        min: -1000,
-        max: 1000,
-        precision: 8
-    }];
-    required Enum req_enum = 7 [(dccl.field) = { codec: "dccl.presence" }];
+    // required fields are unchanged
+    required int32 req_i32 = 1 [(dccl.field) = { min: -100, max: 500 }];
+    required int64 req_i64 = 2 [(dccl.field) = { min: 0, max: 65535 }];
+    required uint32 req_ui32 = 3 [(dccl.field) = { min: 0, max: 1022 }];
+    required uint64 req_ui64 = 4 [(dccl.field) = { min: 100, max: 1123 }];
+    required float req_float = 5
+        [(dccl.field) = { min: -1000, max: 1000, precision: 5 }];
+    required double req_double = 6
+        [(dccl.field) = { min: -1000, max: 1000, precision: 8 }];
+    required Enum req_enum = 7;
 
     // optional fields will gain an extra bit; when unpopulated, the fields are
     // encoded with this bit only
-    optional int32 opt_i32 = 8
-        [(dccl.field) = { codec: "dccl.presence", min: -100, max: 500 }];
-    optional int64 opt_i64 = 9
-        [(dccl.field) = { codec: "dccl.presence", min: 0, max: 65535 }];
-    optional uint32 opt_ui32 = 10
-        [(dccl.field) = { codec: "dccl.presence", min: 0, max: 1022 }];
-    optional uint64 opt_ui64 = 11
-        [(dccl.field) = { codec: "dccl.presence", min: 100, max: 1123 }];
-    optional float opt_float = 12 [(dccl.field) = {
-        codec: "dccl.presence",
-        min: -1000,
-        max: 1000,
-        precision: 5
-    }];
-    optional double opt_double = 13 [(dccl.field) = {
-        codec: "dccl.presence",
-        min: -1000,
-        max: 1000,
-        precision: 8
-    }];
-    optional Enum opt_enum = 14 [(dccl.field) = { codec: "dccl.presence" }];
+    optional int32 opt_i32 = 8 [(dccl.field) = { min: -100, max: 500 }];
+    optional int64 opt_i64 = 9 [(dccl.field) = { min: 0, max: 65535 }];
+    optional uint32 opt_ui32 = 10 [(dccl.field) = { min: 0, max: 1022 }];
+    optional uint64 opt_ui64 = 11 [(dccl.field) = { min: 100, max: 1123 }];
+    optional float opt_float = 12
+        [(dccl.field) = { min: -1000, max: 1000, precision: 5 }];
+    optional double opt_double = 13
+        [(dccl.field) = { min: -1000, max: 1000, precision: 8 }];
+    optional Enum opt_enum = 14;
+    optional bool opt_bool = 15;
+    optional string opt_str = 16 [(dccl.field) = { max_length: 5 }];
+    optional bytes opt_bytes = 17 [(dccl.field) = { max_length: 2 }];
 
     // note: since repeated fields are treated like "required" fields, they are
     // unaffected by the presence codec
-    repeated int32 repeat_i32 = 15 [(dccl.field) = {
-        codec: "dccl.presence",
-        min: -100,
-        max: 500,
-        max_repeat: 2
-    }];
-    repeated Enum repeat_enum = 16
-        [(dccl.field) = { codec: "dccl.presence", max_repeat: 3 }];
+    repeated int32 repeat_i32 = 20
+        [(dccl.field) = { min: -100, max: 500, max_repeat: 2 }];
+    repeated Enum repeat_enum = 21 [(dccl.field) = { max_repeat: 3 }];
 }


### PR DESCRIPTION
Fixes #121 : New base class TimeCodecClock which defaults to std::chrono::system clock. Use TimeCodecClock::set_clock to change the clock in use (must implement now() function: see dccl_header unit tests for example).
Fixes #129 : Cleans up process of loading default codecs so that we can version each codec. Now the find logic for codecs tries both the base name (e.g. "dccl.static") and the name with the codec_version appended (e.g., "dccl.static4"). The versioned name is tried first so it takes precedence if it exists.