### PR TITLE
Switch to M1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,8 +394,7 @@ jobs:
           command: brew update
       - run:
           name: Install CMake
-          # Protobuf@23 has CMake linking problems with abseil that we don't yet support
-          command: brew install cmake protobuf@21
+          command: brew install cmake protobuf
       - run: &run-build
           name: Build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ jobs:
   osx-build:
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: "16.4.0"
+      xcode: "15.0.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -394,7 +394,7 @@ jobs:
           command: brew update
       - run:
           name: Install CMake
-          command: brew install cmake protobuf
+          command: brew install cmake protobuf@21
       - run: &run-build
           name: Build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ jobs:
             - '*.tar.xz'
 
   osx-build:
-    resource_class: m2pro.medium
+    resource_class: macos.m1.medium.gen1
     macos:
       xcode: "16.4.0"
     environment:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # this project is intended to be built out of source by using 
 # > ./build.sh
 
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 # FILE GLOB_RECURSE calls should not follow symlinks by default.
 cmake_policy(SET CMP0009 NEW)


### PR DESCRIPTION
This is the only MacOSX executor now included in the OSS plan.