### PR TITLE
Add degrees_per_second custom units

### DIFF
--- a/src/test/dccl_units/auv_status.proto
+++ b/src/test/dccl_units/auv_status.proto
@@ -90,16 +90,30 @@ message AUVStatus
         max: 1.57
         precision: 2
     }];
+    
     // Angular velocity must use a general system (e.g. "si") that supports both
     // plane_angle and time base dimensions. Using a specialized angle system
-    // (e.g. "angle::degree") would produce a dimensionless result and is rejected
-    // by the protoc-gen-dccl plugin.
+    // (e.g. "angle::degree") would produce a dimensionless result and is
+    // rejected by the protoc-gen-dccl plugin.
     optional double angular_velocity = 14 [(dccl.field) = {
         units { system: "si" derived_dimensions: "angular_velocity" }
         min: -3.14159
         max: 3.14159
         precision: 4
     }];
+
+    required double heading_rate = 15 [(dccl.field) = {
+        units {
+            custom {
+                unit: "dccl::units::degrees_per_second_unit"
+                header: "dccl/units/degrees.h"
+            }
+        }
+        min: -100
+        max: 100.0,
+        precision: 0
+    }];
+
     optional MissionState mission_state = 12;
     enum MissionState
     {

--- a/src/test/dccl_units/test.cpp
+++ b/src/test/dccl_units/test.cpp
@@ -96,6 +96,8 @@ int main()
     status.set_x_with_units(1000 * si::meters);
     status.set_y_with_units(500 * si::meters);
     status.set_heading_with_units(3.1415926535 / 2 * si::radians);
+    status.set_heading_rate_with_units(10 * boost::units::degree::degrees /
+                                       boost::units::si::seconds);
 
     // Test angular velocity: set in rad/s (SI), read back as rad/s
     status.set_angular_velocity_with_units(1.0 * si::radians_per_second);
@@ -110,6 +112,9 @@ int main()
     std::cout << x_nm << std::endl;
     std::cout << y_nm << std::endl;
     std::cout << status.heading_with_units() << std::endl;
+    std::cout << status.heading_rate_with_units() << std::endl;
+
+    assert(status.heading_rate() > 9.9999 && status.heading_rate() < 10.0001); 
 
     Parent p;
     p.set_mass_with_units(2 * si::kilograms);

--- a/src/units/degrees.h
+++ b/src/units/degrees.h
@@ -1,0 +1,19 @@
+#ifndef DCCL_UNITS_DEGREES_H
+#define DCCL_UNITS_DEGREES_H
+
+#include <boost/units/systems/angle/degrees.hpp>
+#include <boost/units/systems/si/angular_velocity.hpp>
+
+namespace dccl
+{
+namespace units
+{
+typedef boost::units::divide_typeof_helper<boost::units::degree::plane_angle,
+                                           boost::units::si::time>::type degrees_per_second_unit;
+
+static const degrees_per_second_unit degrees_per_second;
+
+} // namespace units
+} // namespace dccl
+
+#endif


### PR DESCRIPTION
This pull request adds support for a new `heading_rate` field to the `AUVStatus` message, representing the vehicle's heading rate in degrees per second. It introduces a custom unit for degrees per second, updates the protobuf schema, and extends the test suite to cover this new field.

**Support for heading rate in degrees per second:**

* Added a new `required double heading_rate` field to the `AUVStatus` message in `auv_status.proto`, with units specified as a custom `degrees_per_second_unit` and an appropriate value range.
* Introduced a new header file `degrees.h` that defines the `degrees_per_second_unit` type and a constant for use in code, leveraging Boost.Units.

**Test updates for heading rate:**

* Updated the test in `test.cpp` to set and retrieve `heading_rate` using the new unit, and added an assertion to verify correct value handling. [[1]](diffhunk://#diff-385cbb54643107c6bd1561a3a248fecb7bee678545c1e2a21096c3f689d38700R99-R100) [[2]](diffhunk://#diff-385cbb54643107c6bd1561a3a248fecb7bee678545c1e2a21096c3f689d38700R115-R117)