### PR TITLE
Configure Dependabot for Docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directories: "/.circleci/config/*" 
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Specify Docker as a package ecosystem for Dependabot updates.