### PR TITLE
More dccl4->dccl5 fixes for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ docker-base-noble: &docker-base-noble
     
 ## Pre-declare job templates
 job-template-amd64: &job-template-amd64
-  working_directory: /root/dccl4
+  working_directory: /root/dccl5
   resource_class: large
   steps:
     - checkout
@@ -151,8 +151,8 @@ job-template-deb-cross: &job-template-deb-cross
     - attach-workspace: &attach-deb-workspace
         at: /root/deb
     - run: &install-amd64-dccl-compiler
-        name: Install amd64 dccl4-compiler so that we can execute it in this cross-build container
-        command: dpkg -i /root/deb/dccl4-compiler_*amd64.deb
+        name: Install amd64 dccl5-compiler so that we can execute it in this cross-build container
+        command: dpkg -i /root/deb/dccl5-compiler_*amd64.deb
     - run: *run-update-apt
     - run: *run-import-gpg
     - attach-workspace: *attach-src-workspace
@@ -341,7 +341,7 @@ jobs:
             export NEWVERSION="$(git describe --tags --exclude "3.*" HEAD | sed 's/_/~/' | sed 's/-/+/g')"          
             git config tar.tar.xz.command "xz -c" &&
             mkdir -p /root/src &&
-            git archive --prefix=dccl4-${NEWVERSION}/ -o /root/src/dccl4_${NEWVERSION}.orig.tar.xz HEAD;
+            git archive --prefix=dccl5-${NEWVERSION}/ -o /root/src/dccl5_${NEWVERSION}.orig.tar.xz HEAD;
       - store_artifacts:
           path: /root/src
       - persist_to_workspace:


### PR DESCRIPTION
This pull request updates the CircleCI configuration to transition from using `dccl4` to `dccl5` throughout the build and packaging process. The changes ensure that all references, working directories, and artifacts are aligned with the new `dccl5` version.

**Migration from dccl4 to dccl5:**

* Changed the working directory in the `job-template-amd64` job from `/root/dccl4` to `/root/dccl5` to reflect the new version.
* Updated the installation step in the `job-template-deb-cross` job to use the `dccl5-compiler` package instead of `dccl4-compiler`.
* Modified the archive creation step to generate tarballs and directories prefixed with `dccl5` rather than `dccl4`, ensuring artifacts are correctly named for the new version.