### PR TITLE
5.0 fix enums

### DIFF
--- a/src/apps/pb_plugin/pb_plugin.cpp
+++ b/src/apps/pb_plugin/pb_plugin.cpp
@@ -218,7 +218,7 @@ void DCCLGenerator::generate_message(
             if (desc->options().HasExtension(dccl::msg))
             {
                 if (desc->options().GetExtension(dccl::msg).id() != 0)
-                {
+                {                    
                     std::stringstream id_enum;
                     id_enum << "enum DCCLParameters { DCCL_ID = "
                             << desc->options().GetExtension(dccl::msg).id() << ", "

--- a/src/test/dccl_all_fields/test.cpp
+++ b/src/test/dccl_all_fields/test.cpp
@@ -37,7 +37,10 @@ void decode_check(const std::string& encoded);
 dccl::Codec codec;
 TestMsg msg_in;
 
-int main(int /*argc*/, char* /*argv*/ [])
+static_assert(TestMsg::DCCL_ID == 2);
+static_assert(TestMsg::DCCL_MAX_BYTES == 512);
+
+int main(int /*argc*/, char* /*argv*/[])
 {
     dccl::dlog.connect(dccl::logger::ALL, &std::cerr);
 

--- a/src/test/dccl_all_fields/test.cpp
+++ b/src/test/dccl_all_fields/test.cpp
@@ -37,9 +37,6 @@ void decode_check(const std::string& encoded);
 dccl::Codec codec;
 TestMsg msg_in;
 
-static_assert(TestMsg::DCCL_ID == 2);
-static_assert(TestMsg::DCCL_MAX_BYTES == 512);
-
 int main(int /*argc*/, char* /*argv*/[])
 {
     dccl::dlog.connect(dccl::logger::ALL, &std::cerr);

--- a/src/test/dccl_load_file/test.cpp
+++ b/src/test/dccl_load_file/test.cpp
@@ -32,6 +32,15 @@
 #include "../../binary.h"
 using namespace dccl::test;
 
+
+static_assert(TestMessage1::DCCL_ID == 4);
+static_assert(TestMessage1::DCCL_MAX_BYTES == 64);
+
+static_assert(TestMessage2::DCCL_ID == 5);
+static_assert(TestMessage2::DCCL_MAX_BYTES == 64);
+
+
+
 template <typename Message> void run_test(dccl::Codec& codec, Message& msg_in)
 {
     std::cout << "Try encode..." << std::endl;


### PR DESCRIPTION
This pull request adds compile-time checks to ensure that the protocol message types have the correct DCCL identifiers and maximum byte sizes produced by `protoc-gen-dccl`. Only add to dccl_load_file test as this test is only built if the `protoc-gen-dccl` tool is built.