### PR TITLE
Fix CRC codec verification for optional, repeated, embedded and oneof fields

### DIFF
--- a/src/bitset.h
+++ b/src/bitset.h
@@ -60,6 +60,9 @@ class Bitset : public std::deque<bool>
 
     ~Bitset() = default;
 
+    /// \brief The parent Bitset that get_more_bits() draws from, or nullptr if there is none
+    const Bitset* parent() const { return parent_; }
+
     /// \brief Retrieve more bits from the parent Bitset
     ///
     /// Get (and remove) bits from the little end of the parent bitset and add them to the big end of our bitset,

--- a/src/codecs4/field_codec_crc.h
+++ b/src/codecs4/field_codec_crc.h
@@ -125,6 +125,12 @@ template <int CRCBits> class CRCCodecBase : public v4::DefaultNumericFieldCodec<
         // min() and max() are hardcoded - skip the parent's has_min/has_max checks and
         // call validate_numeric_bounds() directly to verify type range constraints.
         this->validate_numeric_bounds();
+
+        // the CRC is computed over the bits of the message it belongs to, and only the root
+        // message's bits are recovered while decoding
+        FieldCodecBase::require(this->this_descriptor() == this->root_descriptor(),
+                                "CRC codecs are only supported in the root message, not in an "
+                                "embedded message");
     }
 
     /// \brief Compute CRC over all bits accumulated so far (called during encoding).

--- a/src/doc/markdown/page03_codecs.md
+++ b/src/doc/markdown/page03_codecs.md
@@ -270,7 +270,7 @@ message NavigationReport {
 }
 ```
 
-**Important:** The CRC field must be the **last field** in the message body to cover all other fields.
+**Important:** The CRC field must be the **last field** in the message body to cover all other fields, and it must be a field of the message being encoded, not of an embedded message (messages with a CRC field in an embedded message fail validation).
 
 The CRC is computed over the encoded bits of all body fields that precede the CRC field. The value of this field (if set) on encoding is ignored and overwritten with the computed CRC. On decoding, the CRC is recomputed over the same bits and an exception is thrown if it does not match the received value, indicating that the message data may be corrupted.
 

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -124,15 +124,49 @@ void dccl::FieldCodecBase::field_size_repeated(unsigned* bit_size,
     *bit_size += any_size_repeated(wire_values);
 }
 
+namespace
+{
+// Number of bits of the part that have been decoded already, that is, everything up to the field
+// about to be decoded: the part as a whole less whatever is still buffered in the Bitsets it feeds.
+std::ptrdiff_t decoded_offset(const dccl::Bitset& bits, const dccl::Bitset& stream)
+{
+    std::ptrdiff_t buffered = 0;
+    for (const dccl::Bitset* b = &bits; b; b = b->parent()) buffered += b->size();
+
+    return static_cast<std::ptrdiff_t>(stream.size()) - buffered;
+}
+
+// Brings decoded_bits_ up to the field about to be decoded, so that a codec like CRCCodec sees
+// exactly the bits its preceding fields were encoded from. They are copied out of the snapshot
+// taken in base_decode() rather than read back out of the Bitsets the fields decoded from, because
+// codecs are free to shift or otherwise modify those while decoding.
+void update_decoded_bits(dccl::internal::CodecData& codec_data, const dccl::Bitset& bits)
+{
+    const dccl::Bitset& stream = codec_data.stream_bits_;
+    dccl::Bitset& decoded = codec_data.decoded_bits_;
+
+    auto offset = decoded_offset(bits, stream);
+    if (offset < static_cast<std::ptrdiff_t>(decoded.size()) ||
+        offset > static_cast<std::ptrdiff_t>(stream.size()))
+        return;
+
+    for (auto i = decoded.size(); i < static_cast<dccl::Bitset::size_type>(offset); ++i)
+        decoded.push_back(stream[i]);
+}
+
+} // namespace
+
 void dccl::FieldCodecBase::base_decode(Bitset* bits, google::protobuf::Message* field_value,
                                        MessagePart part)
 {
     BaseRAII scoped_globals(this, part, field_value);
     // Reset the accumulated decoded bits and point root_bits_ to it so that codecs like
     // CRCCodec can access all bits decoded before their own field via root_bitset().
-    // decoded_bits_ is populated incrementally by field_decode() for each field.
+    // decoded_bits_ is populated incrementally by field_decode() for each field, using
+    // stream_bits_ as the reference copy of the part being decoded.
     manager().codec_data().decoded_bits_.clear();
     manager().codec_data().root_bits_ = &manager().codec_data().decoded_bits_;
+    manager().codec_data().stream_bits_ = *bits;
     dccl::any value(field_value);
     field_decode(bits, &value, nullptr);
 }
@@ -155,6 +189,11 @@ void dccl::FieldCodecBase::field_decode(Bitset* bits, dccl::any* field_value,
         dlog.is(DEBUG3, DECODE) && dlog << "Message thus far is: " << root_message()->DebugString()
                                         << std::flush;
 
+    // Fields of the root message only: the bits of a field of an embedded message are accounted
+    // for by the embedded message field as a whole.
+    if (field && msg_handler.field_size() == 1)
+        update_decoded_bits(manager().codec_data(), *bits);
+
     Bitset these_bits(bits);
 
     unsigned bits_to_transfer = 0;
@@ -176,9 +215,6 @@ void dccl::FieldCodecBase::field_decode(Bitset* bits, dccl::any* field_value,
 
         any_decode(&these_bits, &wire_value);
         field_post_decode(wire_value, field_value);
-
-        // Append this field's bits to decoded_bits_ so the next sibling field sees them.
-        manager().codec_data().decoded_bits_.append(these_bits);
 
         manager().codec_data().root_bits_ = prev_root_bits;
     }
@@ -204,6 +240,9 @@ void dccl::FieldCodecBase::field_decode_repeated(Bitset* bits, std::vector<dccl:
         dlog.is(DEBUG2, DECODE) &&
             dlog << "Starting repeated decode for field: " << field->DebugString() << std::endl;
 
+    if (field && msg_handler.field_size() == 1)
+        update_decoded_bits(manager().codec_data(), *bits);
+
     Bitset these_bits(bits);
 
     unsigned bits_to_transfer = 0;
@@ -213,11 +252,16 @@ void dccl::FieldCodecBase::field_decode_repeated(Bitset* bits, std::vector<dccl:
     dlog.is(DEBUG2, DECODE) && dlog << "using these " << these_bits.size()
                                     << " bits: " << these_bits << std::endl;
 
+    Bitset* prev_root_bits = manager().codec_data().root_bits_;
+    manager().codec_data().root_bits_ = &manager().codec_data().decoded_bits_;
+
     std::vector<dccl::any> wire_values = *field_values;
     any_decode_repeated(&these_bits, &wire_values);
 
     field_values->clear();
     field_post_decode_repeated(wire_values, field_values);
+
+    manager().codec_data().root_bits_ = prev_root_bits;
 }
 
 void dccl::FieldCodecBase::base_max_size(unsigned* bit_size,
@@ -432,7 +476,7 @@ void dccl::FieldCodecBase::field_hash(std::size_t* hash_value,
     {
         // root level message
         dccl::DCCLMessageOptions dccl_opts = this_descriptor()->options().GetExtension(dccl::msg);
-        dccl_opts.clear_max_bytes(); // max bytes doesn't affect encoding
+        dccl_opts.clear_max_bytes();          // max bytes doesn't affect encoding
         dccl_opts.clear_dynamic_conditions(); // dynamic conditions don't affect wire format
 
         hash_combine(*hash_value, dccl_opts.DebugString());
@@ -784,4 +828,5 @@ dccl::FieldCodecBase::BaseRAII::~BaseRAII()
     field_codec_->manager().codec_data().root_descriptor_ = nullptr;
     field_codec_->manager().codec_data().root_bits_ = nullptr;
     field_codec_->manager().codec_data().decoded_bits_.clear();
+    field_codec_->manager().codec_data().stream_bits_.clear();
 }

--- a/src/field_codec.cpp
+++ b/src/field_codec.cpp
@@ -128,12 +128,12 @@ namespace
 {
 // Number of bits of the part that have been decoded already, that is, everything up to the field
 // about to be decoded: the part as a whole less whatever is still buffered in the Bitsets it feeds.
-std::ptrdiff_t decoded_offset(const dccl::Bitset& bits, const dccl::Bitset& stream)
+std::ptrdiff_t decoded_offset(const dccl::Bitset& bits, const dccl::Bitset& part_bits)
 {
     std::ptrdiff_t buffered = 0;
     for (const dccl::Bitset* b = &bits; b; b = b->parent()) buffered += b->size();
 
-    return static_cast<std::ptrdiff_t>(stream.size()) - buffered;
+    return static_cast<std::ptrdiff_t>(part_bits.size()) - buffered;
 }
 
 // Brings decoded_bits_ up to the field about to be decoded, so that a codec like CRCCodec sees
@@ -142,16 +142,16 @@ std::ptrdiff_t decoded_offset(const dccl::Bitset& bits, const dccl::Bitset& stre
 // codecs are free to shift or otherwise modify those while decoding.
 void update_decoded_bits(dccl::internal::CodecData& codec_data, const dccl::Bitset& bits)
 {
-    const dccl::Bitset& stream = codec_data.stream_bits_;
+    const dccl::Bitset& part_bits = codec_data.part_bits_;
     dccl::Bitset& decoded = codec_data.decoded_bits_;
 
-    auto offset = decoded_offset(bits, stream);
+    auto offset = decoded_offset(bits, part_bits);
     if (offset < static_cast<std::ptrdiff_t>(decoded.size()) ||
-        offset > static_cast<std::ptrdiff_t>(stream.size()))
+        offset > static_cast<std::ptrdiff_t>(part_bits.size()))
         return;
 
     for (auto i = decoded.size(); i < static_cast<dccl::Bitset::size_type>(offset); ++i)
-        decoded.push_back(stream[i]);
+        decoded.push_back(part_bits[i]);
 }
 
 } // namespace
@@ -163,10 +163,10 @@ void dccl::FieldCodecBase::base_decode(Bitset* bits, google::protobuf::Message* 
     // Reset the accumulated decoded bits and point root_bits_ to it so that codecs like
     // CRCCodec can access all bits decoded before their own field via root_bitset().
     // decoded_bits_ is populated incrementally by field_decode() for each field, using
-    // stream_bits_ as the reference copy of the part being decoded.
+    // part_bits_ as the reference copy of the part being decoded.
     manager().codec_data().decoded_bits_.clear();
     manager().codec_data().root_bits_ = &manager().codec_data().decoded_bits_;
-    manager().codec_data().stream_bits_ = *bits;
+    manager().codec_data().part_bits_ = *bits;
     dccl::any value(field_value);
     field_decode(bits, &value, nullptr);
 }
@@ -828,5 +828,5 @@ dccl::FieldCodecBase::BaseRAII::~BaseRAII()
     field_codec_->manager().codec_data().root_descriptor_ = nullptr;
     field_codec_->manager().codec_data().root_bits_ = nullptr;
     field_codec_->manager().codec_data().decoded_bits_.clear();
-    field_codec_->manager().codec_data().stream_bits_.clear();
+    field_codec_->manager().codec_data().part_bits_.clear();
 }

--- a/src/internal/field_codec_data.h
+++ b/src/internal/field_codec_data.h
@@ -64,11 +64,13 @@ struct CodecData
     //
     // Returns nullptr outside of an encode/decode context (e.g., during validate/info).
     Bitset* root_bits_{nullptr};
-    Bitset root_bits_copy_; // unused - kept for ABI stability
-    Bitset decoded_bits_;   // accumulates decoded bits during base_decode()
-    
-    template <typename FieldCodecType>
-    void set_codec_specific_data(std::shared_ptr<dccl::any> data)
+    // Snapshot of the part (head or body) taken before any of it is decoded. Codecs are free
+    // to modify the Bitset they decode from, so the bits a field consumed are recovered from
+    // here rather than read back out of that Bitset.
+    Bitset stream_bits_;
+    Bitset decoded_bits_; // accumulates decoded bits during base_decode()
+
+    template <typename FieldCodecType> void set_codec_specific_data(std::shared_ptr<dccl::any> data)
     {
         codec_specific_[std::type_index(typeid(FieldCodecType))] = data;
     }

--- a/src/internal/field_codec_data.h
+++ b/src/internal/field_codec_data.h
@@ -64,10 +64,10 @@ struct CodecData
     //
     // Returns nullptr outside of an encode/decode context (e.g., during validate/info).
     Bitset* root_bits_{nullptr};
-    // Snapshot of the part (head or body) taken before any of it is decoded. Codecs are free
+    // The part (head or body) as received, copied before any of it is decoded. Codecs are free
     // to modify the Bitset they decode from, so the bits a field consumed are recovered from
     // here rather than read back out of that Bitset.
-    Bitset stream_bits_;
+    Bitset part_bits_;
     Bitset decoded_bits_; // accumulates decoded bits during base_decode()
 
     template <typename FieldCodecType> void set_codec_specific_data(std::shared_ptr<dccl::any> data)

--- a/src/test/dccl_crc/test.cpp
+++ b/src/test/dccl_crc/test.cpp
@@ -61,11 +61,13 @@ int main(int argc, char* argv[])
         msg_in.set_y(-5678);
         msg_in.set_crc(0); // dummy value - overwritten by dccl.crc16 codec
 
-        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Message in:\n" << msg_in.DebugString() << std::endl;
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Message in:\n"
+                                                        << msg_in.DebugString() << std::endl;
         dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Encoding..." << std::endl;
         std::string bytes;
         codec.encode(&bytes, msg_in);
-        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Encoded (hex): " << dccl::hex_encode(bytes) << std::endl;
+        dccl::dlog.is(dccl::logger::INFO) &&
+            dccl::dlog << "Encoded (hex): " << dccl::hex_encode(bytes) << std::endl;
 
         dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Decoding..." << std::endl;
         try
@@ -77,7 +79,8 @@ int main(int argc, char* argv[])
             std::cerr << "UNEXPECTED exception during decode: " << e.what() << std::endl;
             assert(false);
         }
-        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Message out:\n" << msg_out.DebugString() << std::endl;
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Message out:\n"
+                                                        << msg_out.DebugString() << std::endl;
 
         assert(msg_out.x() == msg_in.x());
         assert(msg_out.y() == msg_in.y());
@@ -98,7 +101,9 @@ int main(int argc, char* argv[])
         }
         catch (const std::exception& e)
         {
-            dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Caught expected exception for corrupt CRC-16: " << e.what() << std::endl;
+            dccl::dlog.is(dccl::logger::INFO) &&
+                dccl::dlog << "Caught expected exception for corrupt CRC-16: " << e.what()
+                           << std::endl;
         }
 
         codec.unload<TestCRC16>();
@@ -121,15 +126,18 @@ int main(int argc, char* argv[])
         msg_in.set_y(-9999);
         msg_in.set_crc(0); // dummy value - overwritten by dccl.crc32 codec
 
-        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Message in:\n" << msg_in.DebugString() << std::endl;
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Message in:\n"
+                                                        << msg_in.DebugString() << std::endl;
         dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Encoding..." << std::endl;
         std::string bytes;
         codec.encode(&bytes, msg_in);
-        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Encoded (hex): " << dccl::hex_encode(bytes) << std::endl;
+        dccl::dlog.is(dccl::logger::INFO) &&
+            dccl::dlog << "Encoded (hex): " << dccl::hex_encode(bytes) << std::endl;
 
         dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Decoding..." << std::endl;
         codec.decode(bytes, &msg_out);
-        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Message out:\n" << msg_out.DebugString() << std::endl;
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Message out:\n"
+                                                        << msg_out.DebugString() << std::endl;
 
         assert(msg_out.x() == msg_in.x());
         assert(msg_out.y() == msg_in.y());
@@ -147,7 +155,9 @@ int main(int argc, char* argv[])
         }
         catch (const std::exception& e)
         {
-            dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Caught expected exception for corrupt CRC-32: " << e.what() << std::endl;
+            dccl::dlog.is(dccl::logger::INFO) &&
+                dccl::dlog << "Caught expected exception for corrupt CRC-32: " << e.what()
+                           << std::endl;
         }
 
         codec.unload<TestCRC32>();
@@ -158,7 +168,8 @@ int main(int argc, char* argv[])
     // Test encoding twice gives same result (CRC is deterministic)
     //
     {
-        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "\n=== Testing CRC-16 determinism ===" << std::endl;
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "\n=== Testing CRC-16 determinism ==="
+                                                        << std::endl;
         codec.load<TestCRC16>();
 
         TestCRC16 msg;
@@ -180,10 +191,119 @@ int main(int argc, char* argv[])
         std::string bytes3;
         codec.encode(&bytes3, msg2);
         assert(bytes3 != bytes1);
-        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "CRC differs for different data." << std::endl;
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "CRC differs for different data."
+                                                        << std::endl;
 
         codec.unload<TestCRC16>();
         dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Determinism tests passed!" << std::endl;
+    }
+
+    //
+    // Test CRC-32 over optional, variable length, repeated and embedded fields
+    //
+    {
+        dccl::dlog.is(dccl::logger::INFO) &&
+            dccl::dlog << "\n=== Testing CRC-32 over all field types ===" << std::endl;
+        codec.load<TestCRCAllFields>();
+
+        // once with every optional field set, once with all of them omitted
+        for (int all_set = 1; all_set >= 0; --all_set)
+        {
+            TestCRCAllFields msg_in, msg_out;
+            msg_in.set_x(1234);
+            msg_in.mutable_em()->set_a(7);
+            if (all_set)
+            {
+                msg_in.set_h(42);
+                msg_in.set_y(-4321);
+                msg_in.set_s("hello");
+                msg_in.add_r(1);
+                msg_in.add_r(2);
+                msg_in.mutable_em()->set_b("world");
+                msg_in.mutable_em_opt()->set_a(-7);
+            }
+
+            msg_in.set_crc(0); // dummy value - overwritten by the dccl.crc32 codec
+
+            std::string bytes;
+            codec.encode(&bytes, msg_in);
+            dccl::dlog.is(dccl::logger::INFO) &&
+                dccl::dlog << "Encoded (hex): " << dccl::hex_encode(bytes) << std::endl;
+            codec.decode(bytes, &msg_out);
+            assert(msg_out.crc() != 0);
+            msg_out.set_crc(0); // set on encoding, so not part of the round trip
+            assert(msg_out.DebugString() == msg_in.DebugString());
+
+            // corruption anywhere in the body (all the CRC covers) must still be caught
+            std::string head;
+            codec.encode(&head, msg_in, true);
+            for (std::string::size_type i = head.size(); i < bytes.size(); ++i)
+            {
+                std::string corrupt_bytes = bytes;
+                corrupt_bytes[i] ^= 0x01;
+                if (corrupt_bytes == bytes)
+                    continue;
+
+                try
+                {
+                    TestCRCAllFields corrupt_out;
+                    codec.decode(corrupt_bytes, &corrupt_out);
+                    std::cerr << "ERROR: corrupt message (byte " << i << ") did not throw!"
+                              << std::endl;
+                    assert(false);
+                }
+                catch (const std::exception& e)
+                {
+                    dccl::dlog.is(dccl::logger::INFO) &&
+                        dccl::dlog << "Caught expected exception: " << e.what() << std::endl;
+                }
+            }
+        }
+
+        codec.unload<TestCRCAllFields>();
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "All field type tests passed!"
+                                                        << std::endl;
+    }
+
+    //
+    // Test CRC-32 over a oneof
+    //
+    {
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "\n=== Testing CRC-32 over a oneof ==="
+                                                        << std::endl;
+        codec.load<TestCRCOneof>();
+
+        TestCRCOneof msg_in, msg_out;
+        msg_in.set_y(-4321);
+        msg_in.set_crc(0);
+
+        std::string bytes;
+        codec.encode(&bytes, msg_in);
+        codec.decode(bytes, &msg_out);
+        assert(msg_out.y() == msg_in.y());
+        assert(!msg_out.has_x());
+
+        codec.unload<TestCRCOneof>();
+        dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "Oneof tests passed!" << std::endl;
+    }
+
+    //
+    // A CRC in an embedded message cannot be verified, so it must not load
+    //
+    {
+        dccl::dlog.is(dccl::logger::INFO) &&
+            dccl::dlog << "\n=== Testing CRC in an embedded message ===" << std::endl;
+        try
+        {
+            codec.load<TestCRCBadNested>();
+            std::cerr << "ERROR: CRC in an embedded message loaded!" << std::endl;
+            assert(false);
+        }
+        catch (const std::exception& e)
+        {
+            dccl::dlog.is(dccl::logger::INFO) &&
+                dccl::dlog << "Caught expected exception: " << e.what() << std::endl;
+        }
     }
 
     dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "\nAll CRC tests passed!" << std::endl;

--- a/src/test/dccl_crc/test.proto
+++ b/src/test/dccl_crc/test.proto
@@ -55,3 +55,61 @@ message TestCRC32
         (dccl.field) = { codec: "dccl.crc32" }
     ];
 }
+
+message CRCEmbeddedMsg
+{
+    required int32 a = 1 [(dccl.field) = { min: -100, max: 100 }];
+    optional string b = 2 [(dccl.field).max_length = 8];
+}
+
+// Exercises field types whose codecs modify the Bitset they decode from (optional and
+// variable length fields), plus repeated and embedded fields, all of which must be covered
+// by the CRC just as they are on encoding
+message TestCRCAllFields
+{
+    option (dccl.msg).id = 12;
+    option (dccl.msg).max_bytes = 128;
+    option (dccl.msg).codec_version = 5;
+
+    required int32 x = 1 [(dccl.field) = { min: -10000, max: 10000 }];
+    optional int32 y = 2 [(dccl.field) = { min: -10000, max: 10000 }];
+    optional string s = 3 [(dccl.field).max_length = 10];
+    repeated int32 r = 4 [(dccl.field) = { min: 0, max: 100, max_repeat: 4 }];
+    required CRCEmbeddedMsg em = 5;
+    optional CRCEmbeddedMsg em_opt = 6;
+    optional int32 h = 7 [(dccl.field) = { min: 0, max: 100, in_head: true }];
+
+    required uint32 crc = 100 [(dccl.field) = { codec: "dccl.crc32" }];
+}
+
+// The bits identifying which field of a oneof is set are part of the body, and so must be
+// covered by the CRC as well
+message TestCRCOneof
+{
+    option (dccl.msg).id = 13;
+    option (dccl.msg).max_bytes = 32;
+    option (dccl.msg).codec_version = 5;
+
+    oneof choice
+    {
+        int32 x = 1 [(dccl.field) = { min: -10000, max: 10000 }];
+        int32 y = 2 [(dccl.field) = { min: -10000, max: 10000 }];
+    }
+
+    required uint32 crc = 100 [(dccl.field) = { codec: "dccl.crc32" }];
+}
+
+message CRCBadEmbeddedMsg
+{
+    required int32 a = 1 [(dccl.field) = { min: -100, max: 100 }];
+    required uint32 crc = 100 [(dccl.field) = { codec: "dccl.crc32" }];
+}
+
+message TestCRCBadNested
+{
+    option (dccl.msg).id = 14;
+    option (dccl.msg).max_bytes = 32;
+    option (dccl.msg).codec_version = 5;
+
+    required CRCBadEmbeddedMsg em = 1;
+}


### PR DESCRIPTION
## Problem

A message that carries a `dccl.crc16`/`dccl.crc32` field fails to decode with a spurious CRC mismatch whenever it also contains an optional variable-length field, a repeated field, an embedded message, or a oneof — a clean round trip of a message the library itself encoded:

```
Message: dccl.test.TestCRCAllFields: CRC mismatch. Expected: 0x17704ba2, received: 0x7c475021. Message data may be corrupted.
```

Reproduced on `5.0` by adding `optional string s = 4 [(dccl.field).max_length = 10]` to `dccl_crc`'s own `TestCRC32` and setting it.

## Cause

The CRC codecs verify by recomputing the CRC over the bits decoded before their own field, which `field_decode()` accumulates in `decoded_bits_`. It did that by reading each field's bits back out of the `Bitset` the field had just decoded from — which does not hold in general, because codecs are free to modify that `Bitset` and several do:

- `v3::VarBytesCodec::decode` shifts the presence bit out (`(*bits) >>= 1`), leaving the caller's bits shifted by one
- `v3::PresenceBitCodec::decode` and the v3/v4 message codecs pop the presence bit off

On top of that, `field_decode_repeated()` never accumulated anything, embedded message fields were counted twice (once per inner field, once for the message field as a whole), and a oneof's case bits — consumed by the message codec outside of `field_decode()` — were missed entirely.

## Fix

`base_decode()` copies the part (head or body) before any of it is decoded. Each field of the root message then brings `decoded_bits_` up to its own offset in that copy, computed as the part less whatever is still buffered in the chain of `Bitset`s it feeds. The bits the CRC sees are therefore the bits that were encoded, whatever a codec does with the `Bitset` it decodes from, and every kind of field is accounted for the same way.

A CRC field inside an embedded message covers that message's bits on encoding, but only the root message's bits are recovered while decoding, so it now fails validation with a clear message instead of silently mismatching. Documented in `page03_codecs.md`.

`part_bits_` replaces `root_bits_copy_`, which was unused, so `CodecData`'s layout is unchanged.

## Tests

`dccl_crc` gains coverage that fails on `5.0` and passes here:

- `TestCRCAllFields` — optional numeric, optional variable-length string, repeated, required and optional embedded message, plus an `in_head` field; run once with every optional field set and once with all omitted, each also asserting that flipping a bit in any body byte is caught
- `TestCRCOneof` — a oneof's case bits are covered by the CRC
- `TestCRCBadNested` — a CRC in an embedded message fails to load

Full suite passes (`python_dccl_test` fails in my environment for lack of the `google.protobuf` Python module, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qf7wHCaDaaju8vEwG3hE3W