### PR TITLE
doc: flesh out the channel example with per-channel field omission

### DIFF
--- a/src/doc/markdown/page02_idl.md
+++ b/src/doc/markdown/page02_idl.md
@@ -348,7 +348,7 @@ The available dynamic condition for messages is:
 
 ### Example: fitting one message to several channels
 
-The message-level `max_bytes` condition only *checks* the encoded size; it is the field-level conditions that actually make a message fit. Used together, a single message definition can be sent over channels with very different MTUs, dropping the less important fields on the narrower ones:
+The message-level `max_bytes` condition only *checks* the encoded size; it is the field-level conditions that actually make a message fit. Used together, a single message definition can be sent over channels with very different MTUs:
 
 ```proto
 syntax = "proto2";

--- a/src/doc/markdown/page02_idl.md
+++ b/src/doc/markdown/page02_idl.md
@@ -346,7 +346,9 @@ The available dynamic condition for messages is:
 
 - **max_bytes**: The Lua script must return a numeric value that is the maximum allowed encoded message size in bytes. If the actual encoded size exceeds this value, encoding throws an exception.
 
-### Example: channel-based max_bytes
+### Example: fitting one message to several channels
+
+The message-level `max_bytes` condition only *checks* the encoded size; it is the field-level conditions that actually make a message fit. Used together, a single message definition can be sent over channels with very different MTUs, dropping the less important fields on the narrower ones:
 
 ```proto
 syntax = "proto2";
@@ -356,25 +358,67 @@ message ChannelMessage
 {
     option (dccl.msg) = {
         id: 2,
-        max_bytes: 270,        // absolute upper bound for load()-time validation
+        // worst case (WIFI, full length status) is 31 bytes: this is the bound
+        // checked at load() time
+        max_bytes: 32,
         codec_version: 5,
         dynamic_conditions: {
-            // Return different byte limits based on the channel field
-            max_bytes: "if this.channel == 'ACOUSTIC' then return 60 "
-                       "elseif this.channel == 'IRIDIUM' then return 270 "
-                       "else return 82 end"
+            // per-channel MTU, checked at encode() time
+            max_bytes: "if this.channel == 'ACOUSTIC' then return 8 "
+                       "elseif this.channel == 'IRIDIUM' then return 16 "
+                       "else return 32 end"
         }
     };
 
     enum Channel { WIFI = 1; ACOUSTIC = 2; IRIDIUM = 3; }
 
+    // must be declared before any field whose condition reads it
     required Channel channel = 1;
 
-    repeated uint32 data = 2 [(dccl.field) = { min: 0 max: 4294967295 max_repeat: 20 }];
+    // sent on every channel
+    required int32 x = 2 [(dccl.field) = { min: -10000 max: 10000 }];
+    required int32 y = 3 [(dccl.field) = { min: -10000 max: 10000 }];
+    required int32 z = 4 [(dccl.field) = { min: -1000 max: 0 }];
+    optional uint32 heading = 5 [(dccl.field) = { min: 0 max: 359 }];
+
+    // attitude: dropped on the acoustic channel
+    optional int32 pitch = 6 [(dccl.field) = {
+        min: -90 max: 90
+        dynamic_conditions { omit_if: "this.channel == 'ACOUSTIC'" }
+    }];
+    optional int32 roll = 7 [(dccl.field) = {
+        min: -180 max: 180
+        dynamic_conditions { omit_if: "this.channel == 'ACOUSTIC'" }
+    }];
+
+    // human-readable status: only worth the bytes on WiFi
+    optional string status = 8 [(dccl.field) = {
+        max_length: 20
+        dynamic_conditions { omit_if: "this.channel == 'ACOUSTIC' or this.channel == 'IRIDIUM'" }
+    }];
 }
 ```
 
-In this example, when `channel` is `ACOUSTIC`, the codec enforces a 60-byte limit at encode time; when `channel` is `IRIDIUM`, a 270-byte limit is enforced; otherwise, the static 270-byte limit from `max_bytes` applies. The static `max_bytes: 270` controls the worst-case size validated at `load()` time and must be at least as large as the largest runtime limit.
+Encoding the same fully populated message (with a 19 character `status`) on each channel gives:
+
+| `channel`  | fields encoded                      | encoded size | dynamic limit |
+| ---------- | ----------------------------------- | ------------ | ------------- |
+| `WIFI`     | all                                 | 30 bytes     | 32 bytes      |
+| `ACOUSTIC` | `channel`, `x`, `y`, `z`, `heading` | 8 bytes      | 8 bytes       |
+| `IRIDIUM`  | all but `status`                    | 10 bytes     | 16 bytes      |
+
+A field omitted by `omit_if` costs zero bits, not even the presence bit that an `optional` field normally uses, so dropping `pitch` and `roll` is what takes the acoustic message from 10 bytes down to 8. On the receiving end `has_pitch()` and `has_roll()` return false. Nothing is transmitted to say which fields were dropped: the decoder re-evaluates the same conditions against the message it has decoded so far.
+
+That last point implies an ordering rule: **a field read by a condition must be declared before the fields whose conditions read it** (declaration order in the .proto file, not field number). If `channel` were moved to the bottom of `ChannelMessage`, `this.channel` would be nil when the decoder reaches `pitch`, and decoding would fail or silently produce garbage.
+
+`status` could equally be written as `only_if: "this.channel == 'WIFI'"`, but note the difference: `only_if` also makes the field *required* when the condition is true, so a WiFi message with no `status` set would encode an empty string (11 bytes here) rather than just a cleared presence bit (10 bytes).
+
+Two size errors are worth distinguishing:
+
+- The static `max_bytes` is checked against the worst case size *with every conditional field present* (the conditions are not evaluated at `load()` time). If it is too small, `codec.load()` throws, e.g. with `max_bytes: 30` above: `Actual maximum size of message (31B) exceeds allowed maximum (30B)`. This is a definition error, caught once at startup.
+- The dynamic `max_bytes` is checked against the actual encoded size of one message. If that message is too big for its channel, `codec.encode()` throws, e.g. if the acoustic limit above were 7: `Encoded message size (8B) exceeds dynamic max_bytes limit (7B)`.
+
+So the static `max_bytes` must cover the largest possible message, while the dynamic limits are free to be much smaller.
 
 For more details, see the `dccl_dynamic_conditions_max_bytes` unit test.
 

--- a/src/test/dccl_dynamic_conditions_max_bytes/test.cpp
+++ b/src/test/dccl_dynamic_conditions_max_bytes/test.cpp
@@ -111,6 +111,53 @@ void test_acoustic_too_large()
     dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "test_acoustic_too_large: passed" << std::endl;
 }
 
+// Test the manual's channel example: omit_if drops fields so that each channel's
+// dynamic max_bytes is met. The sizes here are the ones quoted in the manual.
+void test_channel_omit()
+{
+    codec.load<ChannelMessage>();
+
+    ChannelMessage msg;
+    msg.set_x(1234);
+    msg.set_y(-4321);
+    msg.set_z(-50);
+    msg.set_heading(180);
+    msg.set_pitch(3);
+    msg.set_roll(-10);
+    msg.set_status("all systems nominal"); // 19 characters
+
+    std::string bytes;
+    ChannelMessage msg_out;
+
+    msg.set_channel(ChannelMessage::WIFI);
+    bytes.clear(); // dccl::Codec::encode appends
+    codec.encode(&bytes, msg);
+    assert(bytes.size() == 30);
+    codec.decode(bytes, &msg_out);
+    assert(msg.SerializeAsString() == msg_out.SerializeAsString());
+
+    msg.set_channel(ChannelMessage::ACOUSTIC);
+    bytes.clear();
+    codec.encode(&bytes, msg);
+    assert(bytes.size() == 8);
+    msg_out.Clear();
+    codec.decode(bytes, &msg_out);
+    assert(!msg_out.has_pitch() && !msg_out.has_roll() && !msg_out.has_status());
+    assert(msg_out.x() == msg.x() && msg_out.y() == msg.y() && msg_out.z() == msg.z());
+    assert(msg_out.heading() == msg.heading());
+
+    msg.set_channel(ChannelMessage::IRIDIUM);
+    bytes.clear();
+    codec.encode(&bytes, msg);
+    assert(bytes.size() == 10);
+    msg_out.Clear();
+    codec.decode(bytes, &msg_out);
+    assert(msg_out.has_pitch() && msg_out.has_roll() && !msg_out.has_status());
+    assert(msg_out.pitch() == msg.pitch() && msg_out.roll() == msg.roll());
+
+    dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "test_channel_omit: passed" << std::endl;
+}
+
 int main(int argc, char* argv[])
 {
     bool verbose = false;
@@ -125,6 +172,7 @@ int main(int argc, char* argv[])
     test_wifi_ok();
     test_acoustic_ok();
     test_acoustic_too_large();
+    test_channel_omit();
 
     dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "all tests passed" << std::endl;
     return 0;

--- a/src/test/dccl_dynamic_conditions_max_bytes/test.proto
+++ b/src/test/dccl_dynamic_conditions_max_bytes/test.proto
@@ -29,3 +29,55 @@ message TestMaxBytes
 
     repeated uint32 data = 2 [(dccl.field) = { min: 0 max: 4294967295 max_repeat: 20 }];
 }
+
+// The example from the "fitting one message to several channels" section of the
+// user manual (src/doc/markdown/page02_idl.md): field-level omit_if is what
+// shrinks the message to fit each channel's dynamic max_bytes.
+message ChannelMessage
+{
+    option (dccl.msg) = {
+        id: 11,
+        // worst case (WIFI, full length status) is 31 bytes: this is the bound
+        // checked at load() time
+        max_bytes: 32,
+        codec_version: 5,
+        dynamic_conditions: {
+            // per-channel MTU, checked at encode() time
+            max_bytes: "if this.channel == 'ACOUSTIC' then return 8 "
+                       "elseif this.channel == 'IRIDIUM' then return 16 "
+                       "else return 32 end"
+        }
+    };
+
+    enum Channel
+    {
+        WIFI = 1;
+        ACOUSTIC = 2;
+        IRIDIUM = 3;
+    }
+
+    // must be declared before any field whose condition reads it
+    required Channel channel = 1;
+
+    // sent on every channel
+    required int32 x = 2 [(dccl.field) = { min: -10000 max: 10000 }];
+    required int32 y = 3 [(dccl.field) = { min: -10000 max: 10000 }];
+    required int32 z = 4 [(dccl.field) = { min: -1000 max: 0 }];
+    optional uint32 heading = 5 [(dccl.field) = { min: 0 max: 359 }];
+
+    // attitude: dropped on the acoustic channel
+    optional int32 pitch = 6 [(dccl.field) = {
+        min: -90 max: 90
+        dynamic_conditions { omit_if: "this.channel == 'ACOUSTIC'" }
+    }];
+    optional int32 roll = 7 [(dccl.field) = {
+        min: -180 max: 180
+        dynamic_conditions { omit_if: "this.channel == 'ACOUSTIC'" }
+    }];
+
+    // human-readable status: only worth the bytes on WiFi
+    optional string status = 8 [(dccl.field) = {
+        max_length: 20
+        dynamic_conditions { omit_if: "this.channel == 'ACOUSTIC' or this.channel == 'IRIDIUM'" }
+    }];
+}


### PR DESCRIPTION
The manual's dynamic max_bytes example only showed the message-level limit, which checks the encoded size but never makes a message fit. Show both halves together: per-channel max_bytes plus omit_if on the fields that aren't worth the bytes on the narrower channels, with the resulting sizes, the declaration-order requirement, and the difference between the load()-time and encode()-time size errors.

Add the example to the dccl_dynamic_conditions_max_bytes test so the documented sizes and omissions stay honest.


Claude-Session: https://claude.ai/code/session_01VSEiQxyH5V4izGdfitTCeZ