### PR TITLE
Exercise the arithmetic and v3 presence codecs for the remaining field types

### DIFF
--- a/src/test/dccl_arithmetic/test.cpp
+++ b/src/test/dccl_arithmetic/test.cpp
@@ -82,6 +82,17 @@ void run_test(dccl::arith::protobuf::ArithmeticModel& model,
     ++i;
 }
 
+// Runs one repeated field of the given message type through the arithmetic
+// codec. Values are kept to 0 and 1 so the same model and body work for every
+// field type, bool included.
+template <typename Msg> void run_scalar_type_test(dccl::arith::protobuf::ArithmeticModel& model)
+{
+    Msg msg_in;
+    msg_in.add_value(0);
+    msg_in.add_value(1);
+    run_test(model, msg_in);
+}
+
 // usage: dccl_test10 [-v | 1]
 int main(int argc, char* argv[])
 {
@@ -376,6 +387,27 @@ int main(int argc, char* argv[])
         run_test(model, msg_in);
 
         dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "end random test #" << i << std::endl;
+    }
+
+    // Every remaining field type the arithmetic codec is registered for. Only
+    // int32, double and enums were exercised before, so the repeated paths for
+    // these types were never run.
+    {
+        dccl::arith::protobuf::ArithmeticModel model;
+        model.set_name("model");
+        model.set_eof_frequency(10);
+        model.set_out_of_range_frequency(0);
+        model.add_value_bound(0);
+        model.add_frequency(10);
+        model.add_value_bound(1);
+        model.add_frequency(10);
+        model.add_value_bound(2);
+
+        run_scalar_type_test<ArithmeticInt64TestMsg>(model);
+        run_scalar_type_test<ArithmeticUInt32TestMsg>(model);
+        run_scalar_type_test<ArithmeticUInt64TestMsg>(model);
+        run_scalar_type_test<ArithmeticFloatTestMsg>(model);
+        run_scalar_type_test<ArithmeticBoolTestMsg>(model);
     }
 
     // Loading and then unloading the shared library, which reaches

--- a/src/test/dccl_arithmetic/test_arithmetic.proto
+++ b/src/test/dccl_arithmetic/test_arithmetic.proto
@@ -136,3 +136,77 @@ message ArithmeticDouble3TestMsg
 // repeated bool bool_arithmetic_repeat = 113 [(dccl.field).(arithmetic).model =
 // "bool_model",
 //                                             (dccl.field).max_repeat=4];
+
+// The arithmetic codec is registered for every field type, but only int32,
+// double and enums were exercised. These cover the rest, so its repeated
+// encode/decode paths are instantiated and run for each type.
+
+message ArithmeticInt64TestMsg
+{
+    option (dccl.msg).id = 7;
+    option (dccl.msg).max_bytes = 512;
+    option (dccl.msg).codec_version = 5;
+
+    repeated int64 value = 101 [
+        (dccl.field).codec = "dccl.arithmetic",
+        (dccl.field).(arithmetic).model = "model",
+        (dccl.field).(arithmetic).debug_assert = true,
+        (dccl.field).max_repeat = 4
+    ];
+}
+
+message ArithmeticUInt32TestMsg
+{
+    option (dccl.msg).id = 8;
+    option (dccl.msg).max_bytes = 512;
+    option (dccl.msg).codec_version = 5;
+
+    repeated uint32 value = 101 [
+        (dccl.field).codec = "dccl.arithmetic",
+        (dccl.field).(arithmetic).model = "model",
+        (dccl.field).(arithmetic).debug_assert = true,
+        (dccl.field).max_repeat = 4
+    ];
+}
+
+message ArithmeticUInt64TestMsg
+{
+    option (dccl.msg).id = 9;
+    option (dccl.msg).max_bytes = 512;
+    option (dccl.msg).codec_version = 5;
+
+    repeated uint64 value = 101 [
+        (dccl.field).codec = "dccl.arithmetic",
+        (dccl.field).(arithmetic).model = "model",
+        (dccl.field).(arithmetic).debug_assert = true,
+        (dccl.field).max_repeat = 4
+    ];
+}
+
+message ArithmeticFloatTestMsg
+{
+    option (dccl.msg).id = 10;
+    option (dccl.msg).max_bytes = 512;
+    option (dccl.msg).codec_version = 5;
+
+    repeated float value = 101 [
+        (dccl.field).codec = "dccl.arithmetic",
+        (dccl.field).(arithmetic).model = "model",
+        (dccl.field).(arithmetic).debug_assert = true,
+        (dccl.field).max_repeat = 4
+    ];
+}
+
+message ArithmeticBoolTestMsg
+{
+    option (dccl.msg).id = 11;
+    option (dccl.msg).max_bytes = 512;
+    option (dccl.msg).codec_version = 5;
+
+    repeated bool value = 101 [
+        (dccl.field).codec = "dccl.arithmetic",
+        (dccl.field).(arithmetic).model = "model",
+        (dccl.field).(arithmetic).debug_assert = true,
+        (dccl.field).max_repeat = 4
+    ];
+}

--- a/src/test/dccl_presence/test.cpp
+++ b/src/test/dccl_presence/test.cpp
@@ -30,6 +30,8 @@ using namespace dccl::test;
 void test1(dccl::Codec&);
 void test2(dccl::Codec&);
 
+void test3(dccl::Codec& codec);
+
 int main(int argc, char* argv[])
 {
     bool verbose = false;
@@ -46,6 +48,10 @@ int main(int argc, char* argv[])
     codec.info<PresenceMsg>(&dccl::dlog);
     test1(codec);
     test2(codec);
+
+    codec.load<PresenceMsgV3>();
+    codec.info<PresenceMsgV3>(&dccl::dlog);
+    test3(codec);
 
     dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "all tests passed" << std::endl;
 }
@@ -162,4 +168,71 @@ void test2(dccl::Codec& codec)
                       msg_out.repeat_enum().begin()));
 
     dccl::dlog.is(dccl::logger::INFO) && dccl::dlog << "test2 passed" << std::endl;
+}
+
+// Codec version 3 round trip. The v3 presence codec wraps the v2 field codecs,
+// a combination the version 5 cases above never instantiate. Sizes differ
+// between codec versions, so this checks the values survive rather than
+// pinning an encoded length.
+void test3(dccl::Codec& codec)
+{
+    PresenceMsgV3 msg_in;
+
+    msg_in.set_req_i32(-100);
+    msg_in.set_req_i64(65535);
+    msg_in.set_req_ui32(1022);
+    msg_in.set_req_ui64(101);
+    msg_in.set_req_float(900.12345);
+    msg_in.set_req_double(900.12345678);
+    msg_in.set_req_enum(ENUM2_C);
+
+    // once with every optional field absent, once with them all present
+    for (int pass = 0; pass < 2; ++pass)
+    {
+        if (pass == 1)
+        {
+            msg_in.set_opt_i32(-50);
+            msg_in.set_opt_i64(1000);
+            msg_in.set_opt_ui32(500);
+            msg_in.set_opt_ui64(500);
+            msg_in.set_opt_float(-12.5);
+            msg_in.set_opt_double(-12.5);
+            msg_in.set_opt_enum(ENUM2_A);
+            msg_in.set_opt_bool(true);
+            msg_in.set_opt_str("abc");
+            msg_in.set_opt_bytes("\x01\x02");
+            msg_in.add_repeat_i32(1);
+            msg_in.add_repeat_i32(2);
+            msg_in.add_repeat_enum(ENUM2_B);
+        }
+
+        std::string encoded;
+        codec.encode(&encoded, msg_in);
+
+        PresenceMsgV3 msg_out;
+        codec.decode(encoded, &msg_out);
+
+        assert(msg_in.req_i32() == msg_out.req_i32());
+        assert(msg_in.req_i64() == msg_out.req_i64());
+        assert(msg_in.req_ui32() == msg_out.req_ui32());
+        assert(msg_in.req_ui64() == msg_out.req_ui64());
+        assert(fabsf(msg_in.req_float() - msg_out.req_float()) < 1e-4);
+        assert(fabs(msg_in.req_double() - msg_out.req_double()) < 1e-7);
+        assert(msg_in.req_enum() == msg_out.req_enum());
+
+        // absent optionals must stay absent, present ones must survive
+        assert(msg_in.has_opt_i32() == msg_out.has_opt_i32());
+        assert(msg_in.opt_i32() == msg_out.opt_i32());
+        assert(msg_in.opt_i64() == msg_out.opt_i64());
+        assert(msg_in.opt_ui32() == msg_out.opt_ui32());
+        assert(msg_in.opt_ui64() == msg_out.opt_ui64());
+        assert(fabsf(msg_in.opt_float() - msg_out.opt_float()) < 1e-4);
+        assert(fabs(msg_in.opt_double() - msg_out.opt_double()) < 1e-7);
+        assert(msg_in.opt_enum() == msg_out.opt_enum());
+        assert(msg_in.opt_bool() == msg_out.opt_bool());
+        assert(msg_in.opt_str() == msg_out.opt_str());
+        assert(msg_in.opt_bytes() == msg_out.opt_bytes());
+        assert(msg_in.repeat_i32_size() == msg_out.repeat_i32_size());
+        assert(msg_in.repeat_enum_size() == msg_out.repeat_enum_size());
+    }
 }

--- a/src/test/dccl_presence/test.proto
+++ b/src/test/dccl_presence/test.proto
@@ -71,3 +71,45 @@ message PresenceMsg
         [(dccl.field) = { min: -100, max: 500, max_repeat: 2 }];
     repeated Enum repeat_enum = 21 [(dccl.field) = { max_repeat: 3 }];
 }
+
+// The same message under codec version 3, whose presence codec wraps the v2
+// field codecs; nothing else instantiates that combination.
+message PresenceMsgV3
+{
+    option (dccl.msg).id = 11;
+    option (dccl.msg).max_bytes = 64;
+    option (dccl.msg).codec_version = 3;
+    option (dccl.msg).codec_group = "dccl.presence";
+
+    // required fields are unchanged
+    required int32 req_i32 = 1 [(dccl.field) = { min: -100, max: 500 }];
+    required int64 req_i64 = 2 [(dccl.field) = { min: 0, max: 65535 }];
+    required uint32 req_ui32 = 3 [(dccl.field) = { min: 0, max: 1022 }];
+    required uint64 req_ui64 = 4 [(dccl.field) = { min: 100, max: 1123 }];
+    required float req_float = 5
+        [(dccl.field) = { min: -1000, max: 1000, precision: 5 }];
+    required double req_double = 6
+        [(dccl.field) = { min: -1000, max: 1000, precision: 8 }];
+    required Enum req_enum = 7;
+
+    // optional fields will gain an extra bit; when unpopulated, the fields are
+    // encoded with this bit only
+    optional int32 opt_i32 = 8 [(dccl.field) = { min: -100, max: 500 }];
+    optional int64 opt_i64 = 9 [(dccl.field) = { min: 0, max: 65535 }];
+    optional uint32 opt_ui32 = 10 [(dccl.field) = { min: 0, max: 1022 }];
+    optional uint64 opt_ui64 = 11 [(dccl.field) = { min: 100, max: 1123 }];
+    optional float opt_float = 12
+        [(dccl.field) = { min: -1000, max: 1000, precision: 5 }];
+    optional double opt_double = 13
+        [(dccl.field) = { min: -1000, max: 1000, precision: 8 }];
+    optional Enum opt_enum = 14;
+    optional bool opt_bool = 15;
+    optional string opt_str = 16 [(dccl.field) = { max_length: 5 }];
+    optional bytes opt_bytes = 17 [(dccl.field) = { max_length: 2 }];
+
+    // note: since repeated fields are treated like "required" fields, they are
+    // unaffected by the presence codec
+    repeated int32 repeat_i32 = 20
+        [(dccl.field) = { min: -100, max: 500, max_repeat: 2 }];
+    repeated Enum repeat_enum = 21 [(dccl.field) = { max_repeat: 3 }];
+}


### PR DESCRIPTION
Follow-up to #199. Tests only — no source changes.

Both the arithmetic codec and the version 3 presence codec are registered for every field type, but the tests only ever reached a few of them, so most of their per-type instantiations were never run. Neither gap was an error path or an edge case: it was ordinary encode/decode for types nobody had written a message for.

**Function coverage 81.3% → 87.7%**, from 221 lines of test code.

## Arithmetic codec: five missing types

The test covered `int32`, `double` and enums. It now also covers `int64`, `uint32`, `uint64`, `float` and `bool` — the exact set that showed up in the coverage report as uncovered `RepeatedTypedFieldCodec<double, ...>` instantiations, `double` being the arithmetic codec's wire type.

One template helper runs a repeated field of each through the existing round trip. Values are held to 0 and 1 so a single model works for every type, `bool` included, rather than needing a model per type.

**+90 functions.**

## Presence codec: version 3 was never instantiated

`dccl_presence` used `codec_version = 5` throughout. The version 3 presence codec wraps the **v2** field codecs rather than the v4 ones, so `v3::PresenceBitCodec<v2::Default*Codec>` had no coverage at all for any type.

Adds the same message at `codec_version = 3` and round trips it twice, once with the optional fields absent and once with them present.

**+69 functions.**

Two deliberate choices there:

- It checks the values survive rather than pinning an encoded length. The version 5 cases assert `encoded.size() == 17`, which is specific to that codec version; asserting a v3 size would pin a number without testing anything more.
- Floats are compared with the same `1e-4` / `1e-7` tolerances the version 5 cases use. My first attempt compared `SerializeAsString()` and failed — correctly, since fields with `precision` are lossy by design. Worth noting because the byte comparison looks like the stricter test and is in fact simply wrong.

## What did not move, and why

Line coverage stays at 90.4% and branch coverage at 82.0%, to the exact count. These instantiations are straight-line wrappers with no branches of their own, so they add functions without adding either. That was the expectation before starting, not a surprise after.

## Not included

Roughly 51 functions remain in `codecs2/field_codec_default.h` — `v2::DefaultNumericFieldCodec<double, long>` and friends, where the wire type becomes `double` for an integer field. Reaching those means working out what selects that wire type in the v2 codec, which is more excavation than the remaining count justifies. It leaves function coverage about 57 short of 90%.

Getting the average of the three metrics to 90% now rests almost entirely on branch coverage, which has no single lever left — it is case-by-case work on error and edge paths in `field_codec.cpp`, `codec.cpp`, `gen_units_class_plugin.h` and the CLI, with a tail of template artifacts no test can distinguish.

## Verification

- Full suite green, 52/52.
- `scripts/coverage.sh` reports 90.4% line / 87.7% function / 82.0% branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZvdraTc2R7TMTqxG5rdz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZvdraTc2R7TMTqxG5rdz7)_