### PR TITLE
Keep Cryptopp and Lua out of dccl's exported link interface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,19 +40,24 @@ add_library(dccl
   ${SRC}
   )
 
-target_link_libraries(dccl protobuf::libprotobuf ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+# Keyword signature throughout: the plain form puts every dependency in the link interface as
+# well, which writes find_library()'s absolute results into the installed dccl-targets.cmake and
+# so pins consumers to this machine's library paths.
+target_link_libraries(dccl PUBLIC protobuf::libprotobuf ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 
 if(enable_units)
   add_dependencies(dccl protoc-gen-dccl)
 endif()
 
+# Cryptopp and Lua are implementation details: no installed header needs either, and the shared
+# library records them as DT_NEEDED, so a consumer of libdccl does not link them itself.
 if(enable_cryptography)
-  target_link_libraries(dccl ${Cryptopp_LIBRARIES})
+  target_link_libraries(dccl PRIVATE ${Cryptopp_LIBRARIES})
 endif()
 
 if(enable_lua)
-  target_link_libraries(dccl ${LUA_LIBRARY})
+  target_link_libraries(dccl PRIVATE ${LUA_LIBRARY})
 endif()
 
 set_target_properties(dccl PROPERTIES VERSION "${DCCL_VERSION}" SOVERSION "${DCCL_SOVERSION}")


### PR DESCRIPTION
The installed `dccl-targets.cmake` carries the build machine's absolute library paths, and every consumer inherits them:

```cmake
INTERFACE_LINK_LIBRARIES "protobuf::libprotobuf;dl;/usr/lib/x86_64-linux-gnu/libcryptopp.so;/usr/lib/x86_64-linux-gnu/liblua5.3.so"
```

`src/CMakeLists.txt` calls `target_link_libraries(dccl ...)` in the plain, keyword-less form, which adds every dependency to the link *interface* as well as the link line. `Cryptopp_LIBRARIES` and `LUA_LIBRARY` come from `find_library()`, so what gets recorded is an absolute path.

Neither belongs in the interface:

- no installed header needs Cryptopp;
- the only installed header touching Lua is the vendored `thirdparty/sol/sol.hpp`, which only dccl's own sources include (and Lua's include directory is not exported either, so a consumer using it already supplies its own);
- `libdccl.so` records both as `DT_NEEDED`, so a consumer of the shared library never linked them itself.

Marking them `PRIVATE` leaves the export as `"protobuf::libprotobuf;dl"`. The first call is converted to the keyword form as well, since the two signatures cannot be mixed on one target; protobuf, `dl` and the thread library keep the visibility they effectively had.

## How this turned up

Cross-compiling a Goby3 Python application to arm64 against a sysroot of extracted `.deb`s. The recorded `/usr/lib/aarch64-linux-gnu/libcryptopp.so` does not exist at that absolute path inside a sysroot, so the link failed with `No rule to make target`. It works in a plain multiarch cross-build, where the path happens to exist — this is a latent portability problem rather than a live one, but it bites any relocated prefix, sysroot, or install consumed from a different container.

## Verified

- `dccl-targets.cmake` after the change exports `INTERFACE_LINK_LIBRARIES "protobuf::libprotobuf;dl"` and no absolute paths anywhere in `lib/cmake/dccl/`.
- `libdccl.so.31` still records `libcrypto++.so.8` and `liblua5.3.so.0` as `DT_NEEDED`.
- A consumer built with `find_package(dccl)` compiles, links and runs, and its link line names only `libdccl.so` — no Cryptopp, no Lua.
- `enable_testing=ON`, 52/52 tests pass.

## Not changed

Two things noticed in passing and deliberately left alone:

- **A static `dccl` still exports the absolute paths.** `PRIVATE` deps of a static archive are genuinely needed at consumer link time, so CMake exports them regardless. Making that relocatable needs `find_dependency(Cryptopp)` / `find_dependency(Lua)` in `dccl-config.cmake` with the Find modules installed alongside — a larger change, and the packaged builds are shared.
- **`dccl-config.cmake` does not `find_dependency(Protobuf)`.** A consumer that calls `find_package(dccl)` without finding Protobuf first fails with `The link interface of target "dccl" contains: protobuf::libprotobuf but the target was not found`. This predates this PR — the released 5.0.1 behaves identically — and consumers like Goby work because they find Protobuf themselves. Happy to fix it separately if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_016nsf4QMNTfUxkyWh4xGaok)_